### PR TITLE
Add currency selector (related: #12)

### DIFF
--- a/CRM/Donrec/Form/Task/ContributeTask.php
+++ b/CRM/Donrec/Form/Task/ContributeTask.php
@@ -17,6 +17,8 @@ require_once 'CRM/Core/Form.php';
  */
 class CRM_Donrec_Form_Task_ContributeTask extends CRM_Contribute_Form_Task {
 
+  private $availableCurrencies;
+
   function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Issue Donation Receipts', array('domain' => 'de.systopia.donrec')));
 
@@ -35,6 +37,10 @@ class CRM_Donrec_Form_Task_ContributeTask extends CRM_Contribute_Form_Task {
                       ts('Profile', array('domain' => 'de.systopia.donrec')), 
                       CRM_Donrec_Logic_Profile::getAllNames(), 
                       array('class' => 'crm-select2'));
+
+    // add currency selector
+    $this->availableCurrencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
+    $this->addElement('select', 'donrec_contribution_currency', ts('Currency'), $this->availableCurrencies);
 
     // call the (overwritten) Form's method, so the continue button is on the right...
     CRM_Core_Form::addDefaultButtons(ts('Continue', array('domain' => 'de.systopia.donrec')));
@@ -81,6 +87,10 @@ class CRM_Donrec_Form_Task_ContributeTask extends CRM_Contribute_Form_Task {
     // created between two specific dates)
     $values = $this->exportValues();
     $values['contribution_ids'] = $this->_contributionIds;
+
+    // get the currency ISO code
+    $currencyId = $values['donrec_contribution_currency'];
+    $values['donrec_contribution_currency'] = $this->availableCurrencies[ $currencyId ];
 
     //set url_back as session-variable
     $session = CRM_Core_Session::singleton();

--- a/CRM/Donrec/Form/Task/Create.php
+++ b/CRM/Donrec/Form/Task/Create.php
@@ -17,6 +17,8 @@ require_once 'CRM/Core/Form.php';
  */
 class CRM_Donrec_Form_Task_Create extends CRM_Core_Form {
 
+  private $availableCurrencies;
+
   function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Issue Donation Receipts', array('domain' => 'de.systopia.donrec')));
 
@@ -36,6 +38,10 @@ class CRM_Donrec_Form_Task_Create extends CRM_Core_Form {
                       ts('Profile', array('domain' => 'de.systopia.donrec')), 
                       CRM_Donrec_Logic_Profile::getAllNames(), 
                       array('class' => 'crm-select2'));
+
+    // add currency selector
+    $this->availableCurrencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
+    $this->addElement('select', 'donrec_contribution_currency', ts('Currency'), $this->availableCurrencies);
 
     $this->addDefaultButtons(ts('Continue', array('domain' => 'de.systopia.donrec')));
   }
@@ -88,6 +94,10 @@ class CRM_Donrec_Form_Task_Create extends CRM_Core_Form {
     $values = $this->exportValues();
     $contactId = empty($_REQUEST['cid']) ? NULL : $_REQUEST['cid'];
     $values['contact_id'] = $contactId;
+
+    // get the currency ISO code
+    $currencyId = $values['donrec_contribution_currency'];
+    $values['donrec_contribution_currency'] = $this->availableCurrencies[ $currencyId ];
 
     //set url_back as session-variable
     $session = CRM_Core_Session::singleton();

--- a/CRM/Donrec/Form/Task/DonrecTask.php
+++ b/CRM/Donrec/Form/Task/DonrecTask.php
@@ -17,6 +17,8 @@ require_once 'CRM/Core/Form.php';
  */
 class CRM_Donrec_Form_Task_DonrecTask extends CRM_Contact_Form_Task {
 
+  private $availableCurrencies;
+
   function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Issue Donation Receipts', array('domain' => 'de.systopia.donrec')));
 
@@ -35,6 +37,10 @@ class CRM_Donrec_Form_Task_DonrecTask extends CRM_Contact_Form_Task {
                       ts('Profile', array('domain' => 'de.systopia.donrec')), 
                       CRM_Donrec_Logic_Profile::getAllNames(), 
                       array('class' => 'crm-select2'));
+
+    // add currency selector
+    $this->availableCurrencies = array_keys(CRM_Core_OptionGroup::values('currencies_enabled'));
+    $this->addElement('select', 'donrec_contribution_currency', ts('Currency'), $this->availableCurrencies);
 
     // call the (overwritten) Form's method, so the continue button is on the right...
     CRM_Core_Form::addDefaultButtons(ts('Continue', array('domain' => 'de.systopia.donrec')));
@@ -81,6 +87,10 @@ class CRM_Donrec_Form_Task_DonrecTask extends CRM_Contact_Form_Task {
     // created between two specific dates)
     $values = $this->exportValues();
     $values['contact_ids'] = $this->_contactIds;
+
+    // get the currency ISO code
+    $currencyId = $values['donrec_contribution_currency'];
+    $values['donrec_contribution_currency'] = $this->availableCurrencies[ $currencyId ];
 
     //set url_back as session-variable
     $session = CRM_Core_Session::singleton();

--- a/CRM/Donrec/Logic/Selector.php
+++ b/CRM/Donrec/Logic/Selector.php
@@ -38,6 +38,8 @@ class CRM_Donrec_Logic_Selector {
       $query_date_limit .= " AND `receive_date` <= '$formatted_date_to'";
     }
 
+    $currency = $values['donrec_contribution_currency'];
+
     // get table- and column name
     $table_query = "SELECT `cg`.`table_name`,
                            `cf`.`column_name`
@@ -94,7 +96,7 @@ class CRM_Donrec_Logic_Selector {
                   AND (`non_deductible_amount` = 0 OR `non_deductible_amount` IS NULL)
                   AND `contribution_status_id` = 1
                   AND `is_test` = 0
-                  AND `currency` = 'EUR'
+                  AND `currency` = '$currency'
                   AND existing_receipt.`entity_id` IS NULL;";
 
     // execute the query

--- a/CRM/Donrec/Logic/Snapshot.php
+++ b/CRM/Donrec/Logic/Snapshot.php
@@ -580,7 +580,8 @@ class CRM_Donrec_Logic_Snapshot {
       SUM(total_amount) AS total_amount,
       created_timestamp AS creation_date,
       date_from AS date_from,
-      date_to AS date_to
+      date_to AS date_to,
+      currency
       FROM donrec_snapshot
       WHERE snapshot_id = $id";
 
@@ -622,7 +623,8 @@ class CRM_Donrec_Logic_Snapshot {
       'date_to' => $result1->date_to,
       'status' => $status,
       'singleOrBulk' => self::singleOrBulk($id),
-      'exporters' => $snapshot->getExporters($id)
+      'exporters' => $snapshot->getExporters($id),
+      'currency' => $result1->currency
     );
     return $statistic;
   }

--- a/templates/CRM/Donrec/Form/Task/creation_parameters.tpl
+++ b/templates/CRM/Donrec/Form/Task/creation_parameters.tpl
@@ -38,6 +38,14 @@
     </td>
   </tr>
   <tr>
+    <td class="label">
+      {ts domain="de.systopia.donrec"}Select the currency{/ts}:
+    </td>
+    <td>
+      {$form.donrec_contribution_currency.html}
+    </td>
+  </tr>
+  <tr>
     <td></td>
     <td>
       <div class="crm-submit-buttons">

--- a/templates/CRM/Donrec/Page/Staging.tpl
+++ b/templates/CRM/Donrec/Page/Staging.tpl
@@ -51,7 +51,7 @@
         </div>
         <div class="crm-summary-row">
           <div class="crm-label">{ts domain="de.systopia.donrec"}total amount{/ts}</div>
-          <div class="crm-content">{$statistic.total_amount|crmMoney:EUR}</div>
+          <div class="crm-content">{$statistic.total_amount|crmMoney:$statistic.currency}</div>
         </div>
         <div class="crm-summary-row">
           <div class="crm-label">{ts domain="de.systopia.donrec"}Period from{/ts}</div>


### PR DESCRIPTION
Hello again,

This is a refactored (in just one commit) version of the changes I was talking about a few months ago (https://github.com/systopia/de.systopia.donrec/issues/12#issuecomment-231034065). It's also rebased so it works with the current version of the extension.

What it does is to add a currency selector that shows the currencies that the CiviCRM instance having the extension has enabled:

* In case the system just have one currency and it's euros, this commit will add a selector currency with only one option (EUR) and it won't actually do anything.
* In case the system just have one currency and it's not euros, this commit will add a selector currency with only one option, but in this case the search will return the corresponding contributions.
* In case the system have more than one currency enabled, this commit will allow to select the currency you want to emit the receipts for.

![screenshot_20170201_120513](https://cloud.githubusercontent.com/assets/1746692/22506143/ba6fa930-e876-11e6-8bb2-fcaa3a33ee92.png)

What do you think about it?