### PR TITLE
Add OVERWRITE to zip mode

### DIFF
--- a/CRM/Donrec/Exporters/GroupedPDF.php
+++ b/CRM/Donrec/Exporters/GroupedPDF.php
@@ -147,7 +147,7 @@ class CRM_Donrec_Exporters_GroupedPDF extends CRM_Donrec_Exporters_BasePDF {
 
     // add files to sub-archives
     // open main archive and add sub-archives
-    if ($outerArchive->open($fileURL, ZIPARCHIVE::CREATE) === TRUE) {
+    if ($outerArchive->open($fileURL, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE) === TRUE) {
       foreach($pageCountArr as $entry) {
         foreach ($entry as $item) {
           if($item[0] && $item[2]) { // if page count and file name exists

--- a/CRM/Donrec/Exporters/PDF.php
+++ b/CRM/Donrec/Exporters/PDF.php
@@ -74,7 +74,7 @@ class CRM_Donrec_Exporters_PDF extends CRM_Donrec_Exporters_BasePDF {
     $ids = $snapshot->getIds();
     $toRemove = array();
 
-    if ($zip->open($archiveFileName, ZIPARCHIVE::CREATE) === TRUE) {
+    if ($zip->open($archiveFileName, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE) === TRUE) {
       foreach($ids as $id) {
         $proc_info = $snapshot->getProcessInformation($id);
         if(!empty($proc_info)) {


### PR DESCRIPTION
We had a problem in which zip creation failed with error code 19. We are running PHP 7.3.4. Adding OVERWRITE - which is likely what you want since this is a temporary file - fixes the problem while it should be compatible to older PHP versions. 