### PR TITLE
Update legal notice in German default template (was: Hinweistext in Standardvorlage hat sich geändert)

### DIFF
--- a/templates/Export/default_template.tpl
+++ b/templates/Export/default_template.tpl
@@ -283,9 +283,20 @@ Ob es sich um den Verzicht auf Erstattung von Aufwendungen handelt, ist der Anla
 </div>
 
 <div class="footer">
-    <p><strong>Hinweis:</strong><br /> Wer vorsätzlich oder grob fahrlässig eine unrichtige Zuwendungsbestätigung erstellt oder veranlasst, dass Zuwendungen nicht zu den in der Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet werden, haftet für die entgangene Steuer (§ 10b Abs. 4 EStG, §9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
-Diese Bestätigung wird nicht als Nachweis für die steuerliche Berücksichtigung der Zuwendung anerkannt, wenn das Datum des Freistellungsbescheides länger als 5 Jahre bzw. das Datum der Feststellung der Einhaltung der satzungsmäßigen Voraussetzungen nach § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides zurückliegt (§ 63 Abs. 5 AO).
-</p>
+    <p>
+      <strong>Hinweis:</strong><br />
+      Wer vorsätzlich oder grob fahrlässig eine unrichtige Zuwendungsbestätigung
+      erstellt oder veranlasst, dass Zuwendungen nicht zu den in der
+      Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet
+      werden, haftet für die entgangene Steuer
+      (§ 10b Abs. 4 EStG, §9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
+      Diese Bestätigung wird nicht als Nachweis für die steuerliche
+      Berücksichtigung der Zuwendung anerkannt, wenn das Datum des
+      Freistellungsbescheides länger als 5 Jahre bzw. das Datum der Feststellung
+      der Einhaltung der satzungsmäßigen Voraussetzungen nach
+      § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides
+      zurückliegt (§ 63 Abs. 5 AO).
+    </p>
 </div>
 
 {if $items}

--- a/templates/Export/default_template.tpl
+++ b/templates/Export/default_template.tpl
@@ -283,12 +283,9 @@ Ob es sich um den Verzicht auf Erstattung von Aufwendungen handelt, ist der Anla
 </div>
 
 <div class="footer">
-    <p><strong>Hinweis:</strong><br />Hinweis: Wer vorsätzlich oder grob fahrlässig eine unrichtige Zuwendungsbestätigung erstellt oder wer veranlasst, dass Zuwendungen nicht
-zu den in der Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet werden, haftet für die Steuer, die dem Fiskus
-durch einen etwaigen Abzug der Zuwendungen beim Zuwendenden entgeht (§ 10b Abs. 4 EStG, § 9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
-Diese Bestätigung wird nicht als Nachweis für die steuerliche Berücksichtigung der Zuwendung anerkannt, wenn das Datum des
-Freistellungsbescheides länger als 5 Jahre bzw. das Datum der vorläufigen Bescheinigung länger als 3 Jahre seit Ausstellung der Bestätigung
-zurückliegt (BMF vom 15.12.1994 - BStBl I S. 884).</p>
+    <p><strong>Hinweis:</strong><br /> Wer vorsätzlich oder grob fahrlässig eine unrichtige Zuwendungsbestätigung erstellt oder veranlasst, dass Zuwendungen nicht zu den in der Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet werden, haftet für die entgangene Steuer (§ 10b Abs. 4 EStG, §9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
+Diese Bestätigung wird nicht als Nachweis für die steuerliche Berücksichtigung der Zuwendung anerkannt, wenn das Datum des Freistellungsbescheides länger als 5 Jahre bzw. das Datum der Feststellung der Einhaltung der satzungsmäßigen Voraussetzungen nach § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides zurückliegt (§ 63 Abs. 5 AO).
+</p>
 </div>
 
 {if $items}

--- a/templates/Export/default_template.tpl
+++ b/templates/Export/default_template.tpl
@@ -289,13 +289,14 @@ Ob es sich um den Verzicht auf Erstattung von Aufwendungen handelt, ist der Anla
       erstellt oder veranlasst, dass Zuwendungen nicht zu den in der
       Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet
       werden, haftet für die entgangene Steuer
-      (§ 10b Abs. 4 EStG, §9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
+      (§&nbsp;10b&nbsp;Abs.&nbsp;4&nbsp;EStG, §9&nbsp;Abs.&nbsp;3&nbsp;KStG,
+      §&nbsp;9&nbsp;Nr.&nbsp;5&nbsp;GewStG).
       Diese Bestätigung wird nicht als Nachweis für die steuerliche
       Berücksichtigung der Zuwendung anerkannt, wenn das Datum des
       Freistellungsbescheides länger als 5 Jahre bzw. das Datum der Feststellung
       der Einhaltung der satzungsmäßigen Voraussetzungen nach
-      § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides
-      zurückliegt (§ 63 Abs. 5 AO).
+      §&nbsp;60a&nbsp;Abs.&nbsp;1&nbsp;AO länger als 3 Jahre seit Ausstellung
+      des Bescheides zurückliegt (§&nbsp;63&nbsp;Abs.&nbsp;5&nbsp;AO).
     </p>
 </div>
 


### PR DESCRIPTION
Der Hinweistext für eine ZWB hat sich geändert:

    Hinweis: Wer vorsätzlich oder grob fahrlässig eine unrichtige Zuwendungsbestätigung erstellt oder veranlasst, dass Zuwendungen nicht zu den in der Zuwendungsbestätigung angegebenen steuerbegünstigten Zwecken verwendet werden, haftet für die entgangene Steuer (§ 10b Abs. 4 EStG, §9 Abs. 3 KStG, § 9 Nr. 5 GewStG).
    Diese Bestätigung wird nicht als Nachweis für die steuerliche Berücksichtigung der Zuwendung anerkannt, wenn das Datum des Freistellungsbescheides länger als 5 Jahre bzw. das Datum der Feststellung der Einhaltung der satzungsmäßigen Voraussetzungen nach § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides zurückliegt (§ 63 Abs. 5 AO).
