### PR TITLE
Fix rebook contribution.

### DIFF
--- a/CRM/Donrec/Form/Task/Rebook.php
+++ b/CRM/Donrec/Form/Task/Rebook.php
@@ -129,6 +129,10 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
     $completedStatus = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
     $contribution_fieldKeys = CRM_Contribute_DAO_Contribution::fieldKeys();
     $sepa_ooff_payment_id = CRM_Core_OptionGroup::getValue('payment_instrument', 'OOFF', 'name');
+    // Get contribution default return properties.
+    $contribution_return = CRM_Contribute_BAO_Query::defaultReturnProperties(CRM_Contact_BAO_Query::MODE_CONTRIBUTE);
+    // Add non-default fields.
+    $contribution_return = array_merge($contribution_fieldKeys, $contribution_return);
 
     $contribution_count = count($contribution_ids);
     $session = CRM_Core_Session::singleton();
@@ -139,6 +143,7 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
           'version' => 3,
           'sequential' => 1,
           'id' => $contributionId,
+          'return' => array_keys($contribution_return),
       );
       $contribution = civicrm_api('Contribution', 'getsingle', $params);
 


### PR DESCRIPTION
When transferring a contribution, not all the fields of the original contribution are copied (for example: contribution_page_id).

This error arises because Contribution.getsingle does not return all fields in the contribution: https://github.com/systopia/de.systopia.donrec/blob/20a74225a358007c9a64b0e987727846f59b4774/CRM/Donrec/Form/Task/Rebook.php#L143

Issue: #107 