### PR TITLE
view PDF: `readfile` after header settings

### DIFF
--- a/CRM/Donrec/Page/Tempfile.php
+++ b/CRM/Donrec/Page/Tempfile.php
@@ -28,8 +28,6 @@ class CRM_Donrec_Page_Tempfile extends CRM_Core_Page {
     if (!empty($_REQUEST['path'])) {
       $filename = sys_get_temp_dir() . '/' . self::PREFIX . $_REQUEST['path'];
       if (file_exists($filename)) {
-        // dump file contents in stream
-        readfile($filename);
 
         // set file name
         if (empty($_REQUEST['name'])) {
@@ -44,6 +42,9 @@ class CRM_Donrec_Page_Tempfile extends CRM_Core_Page {
         } else {
           header('Content-Type: ' . $_REQUEST['type']);
         }
+
+        // dump file contents in stream
+        readfile($filename);
 
         CRM_Utils_System::civiExit();
       }


### PR DESCRIPTION
Hi, 
in Wordpress (in Drupal I don't know) view receipt PDF shows pdf content in browser instead of PDF file.
There was an error in `wp-content/uploads/civicrm/ext/de.systopia.donrec/CRM/Donrec/Page/Tempfile.php`: `readfile` instruction was before header settings.