### PR TITLE
Fix for issue #131

### DIFF
--- a/donrec.php
+++ b/donrec.php
@@ -193,7 +193,12 @@ function donrec_civicrm_searchColumns($objectName, &$headers,  &$values, &$selec
             // this contribution is o.k. => add the rebook action
             $contribution_id = $row['contribution_id'];
             $this_action = str_replace('__CONTRIBUTION_ID__', $contribution_id, $action);
-            $values[$rownr]['action'] = str_replace('</span>', $this_action.'</span>', $row['action']);
+            if (strpos($row['action'], '</ul>') !== FALSE) {
+              $values[$rownr]['action'] = str_replace('</ul></span>', '<li>'.$this_action.'</li></ul></span>', $row['action']);
+            }
+            else {
+              $values[$rownr]['action'] = str_replace('</span>', $this_action.'</span>', $row['action']);
+            }
           }
         }
       }


### PR DESCRIPTION
**Before**

When this extension is used together with https://github.com/lcdservices/biz.lcdservices.movecontrib then the move contribution action is not visible in the action menu on the contribution tab of a contact.

**After**

The move contribution action is visible in the action menu next to a contribution on the contribution tab on a contact summary screen.

See also: https://github.com/systopia/de.systopia.donrec/issues/131