### PR TITLE
start to fix deprecated/removed CRM_Core_OptionGroup::getValue

### DIFF
--- a/CRM/Donrec/Exporters/EmailPDF.php
+++ b/CRM/Donrec/Exporters/EmailPDF.php
@@ -107,7 +107,7 @@ class CRM_Donrec_Exporters_EmailPDF extends CRM_Donrec_Exporters_EncryptedPDF {
         civicrm_api3('Activity', 'create', array(
           'activity_type_id'   => $this->getEmailErrorActivityID(),
           'subject'            => E::ts("Donation receipt not delivered"),
-          'status_id'          => CRM_Core_OptionGroup::getValue('activity_status', 'Scheduled', 'name'),
+          'status_id'          => CRM_Core_OptionGroup::getValue('activity_status', 'Scheduled', 'name'), // TODO CRM_Core_PseudoConstant::getKey('BAO_NAME ???', 'activity_status', 'Scheduled')
           'activity_date_time' => date('YmdHis'),
           'source_contact_id'  => $receipt['created_by'],
           'target_id'          => $receipt['contact_id'],
@@ -147,8 +147,7 @@ class CRM_Donrec_Exporters_EmailPDF extends CRM_Donrec_Exporters_EncryptedPDF {
 
       // Get from e-mail from profile or load domain default.
       if ($from_email_id = CRM_Donrec_Logic_Profile::getProfile($receipt['profile_id'])->getDataAttribute('from_email')) {
-        $fromEmailAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND value = ' . $from_email_id);
-        foreach ($fromEmailAddress as $key => $value) {
+        $fromEmailAddress = CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, ' AND value = ' . $from_email_id); // TODO is CRM_Core_OptionGroup::values still allowed or also deprecated?
           $from_email_address = CRM_Utils_Mail::pluckEmailFromHeader($value);
           $fromArray = explode('"', $value);
           $from_email_name = CRM_Utils_Array::value(1, $fromArray);
@@ -250,7 +249,7 @@ class CRM_Donrec_Exporters_EmailPDF extends CRM_Donrec_Exporters_EncryptedPDF {
    */
   public function getEmailErrorActivityID() {
     if ($this->activity_type_id === NULL) {
-      $this->activity_type_id = (int) CRM_Core_OptionGroup::getValue('activity_type', 'donrec_email_failed', 'name');
+      $this->activity_type_id = (int) CRM_Core_OptionGroup::getValue('activity_type', 'donrec_email_failed', 'name'); // TODO CRM_Core_PseudoConstant::getKey('BAO_NAME ???', 'activity_type', 'donrec_email_failed')
       if (!$this->activity_type_id) {
         // create new activity type
         $option_group = civicrm_api3('OptionGroup', 'getsingle', array('name' => 'activity_type'));

--- a/CRM/Donrec/Form/Task/Rebook.php
+++ b/CRM/Donrec/Form/Task/Rebook.php
@@ -125,10 +125,10 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
   static function rebook($contribution_ids, $contact_id, $redirect_url = NULL) {
     $contact_id = (int) $contact_id;
     $excludeList = array('id', 'contribution_id', 'trxn_id', 'invoice_id', 'cancel_date', 'cancel_reason', 'address_id', 'contribution_contact_id', 'contribution_status_id');
-    $cancelledStatus = CRM_Core_OptionGroup::getValue('contribution_status', 'Cancelled', 'name');
-    $completedStatus = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+    $cancelledStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status', 'Cancelled');
+    $completedStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status', 'Completed');
     $contribution_fieldKeys = CRM_Contribute_DAO_Contribution::fieldKeys();
-    $sepa_ooff_payment_id = CRM_Core_OptionGroup::getValue('payment_instrument', 'OOFF', 'name');
+    $sepa_ooff_payment_id = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument', 'OOFF');
     // Get contribution default return properties.
     $contribution_return = CRM_Contribute_BAO_Query::defaultReturnProperties(CRM_Contact_BAO_Query::MODE_CONTRIBUTE);
     // Add non-default fields.
@@ -167,7 +167,7 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
             'version'                 => 3,
             'contribution_contact_id' => $contact_id,
             'contribution_status_id'  => $completedStatus,
-            'payment_instrument_id'   => CRM_Core_OptionGroup::getValue('payment_instrument', $contribution['instrument_id'], 'id'), // this seems to be an API bug
+            'payment_instrument_id'   => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument', $contribution['instrument_id']), // this seems to be an API bug
         );
         foreach ($contribution as $key => $value) {
 
@@ -278,7 +278,7 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
     }
 
     // Check contributions
-    $completed = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+    $completed = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status', 'Completed');
     $arr = explode(",", $contributionIds);
     foreach ($arr as $contributionId) {
       $contribution = new CRM_Contribute_DAO_Contribution();

--- a/donrec.php
+++ b/donrec.php
@@ -148,7 +148,7 @@ function donrec_civicrm_searchColumns($objectName, &$headers,  &$values, &$selec
     // ************************************
     // only offer rebook only if the user has the correct permissions
     if (CRM_Core_Permission::check('edit contributions')) {
-      $contribution_status_complete = (int) CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+      $contribution_status_complete = (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status', 'Completed');
       $title = E::ts('Rebook');
       $url = CRM_Utils_System::url('civicrm/donrec/rebook', "contributionIds=__CONTRIBUTION_ID__");
       $action = "<a title=\"$title\" class=\"action-item action-item\" href=\"$url\">$title</a>";

--- a/tests/phpunit/CRM/Donrec/BaseTestCase.php
+++ b/tests/phpunit/CRM/Donrec/BaseTestCase.php
@@ -48,7 +48,7 @@ class CRM_Donrec_BaseTestCase extends \PHPUnit\Framework\TestCase implements \Ci
    *         bochan -at- systopia.de
    */
   function generateContributions($count = 2) {
-    $contribution_status_pending = (int) CRM_Core_OptionGroup::getValue('contribution_status', 'Pending', 'name');
+    $contribution_status_pending = (int) CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status', 'Pending');
     $this->assertNotEmpty($contribution_status_pending, "Could not find the 'Pending' contribution status.");
 
     $create_contribution = array(


### PR DESCRIPTION
With the latest CiviCRM Core update the system is failing to load any contributions in profiles because the extension is using deprecated methods that have been removed now. This PR solved the immediate issue for us (regular CiviCRM functionality is working again).
(--> also see https://github.com/systopia/de.systopia.donrec/issues/125)

I didn't have the chance yet to thoroughly test whether the donrec functionality is correctly implemented using the new methods here. And I am unsure what the correct BAO for some of the code is.

CiviCRM Developer Doc Reference: https://docs.civicrm.org/dev/en/latest/framework/pseudoconstant/
StackExchange question to get input how to do this correctly: https://civicrm.stackexchange.com/questions/44840/how-to-replace-deprecated-crm-core-optiongroupgetvalue-with-crm-core-pseudocon