### PR TITLE
Do not overwrite the issued_on field when copying a donation receipt

### DIFF
--- a/CRM/Donrec/Logic/Receipt.php
+++ b/CRM/Donrec/Logic/Receipt.php
@@ -181,7 +181,7 @@ class CRM_Donrec_Logic_Receipt extends CRM_Donrec_Logic_ReceiptTokens {
     $receipt_table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt');
     $uid = CRM_Donrec_Logic_Settings::getLoggedInContactID();
 
-    $exclude = array('status', 'issued_on', 'issued_by', 'original_file');
+    $exclude = array('status', 'issued_by', 'original_file');
     $field_query = '`entity_id`';
     foreach($receipt_fields as $key => $field) {
       if (!in_array($key, $exclude)) {
@@ -191,13 +191,11 @@ class CRM_Donrec_Logic_Receipt extends CRM_Donrec_Logic_ReceiptTokens {
     $query = "
       INSERT INTO `$receipt_table` (
         `$receipt_fields[status]`,
-        `$receipt_fields[issued_on]`,
         `$receipt_fields[issued_by]`,
         $field_query
       )
       SELECT
         'COPY' AS `$receipt_fields[status]`,
-        NOW() AS `$receipt_fields[issued_on]`,
         $uid AS `$receipt_fields[issued_by]`,
         $field_query
       FROM `$receipt_table`

--- a/templates/Export/default_template.tpl
+++ b/templates/Export/default_template.tpl
@@ -275,7 +275,7 @@ Ob es sich um den Verzicht auf Erstattung von Aufwendungen handelt, ist der Anla
 </div>
 
 <div class="signature">
-  {$organisation.city}, den {$today|crmDate:$config->dateformatFull}
+  {$organisation.city}, den {$issued_on|crmDate:$config->dateformatFull}
     <p>
     [Unterschrift]<br />
 
@@ -300,7 +300,7 @@ Ob es sich um den Verzicht auf Erstattung von Aufwendungen handelt, ist der Anla
 
 {if $items}
 <div class="newpage">
-<h2 class='box'>Anlage zur Sammelbestätigung vom {$today|crmDate:'%d.%m.%Y'} für {$contributor.display_name}</h2>
+<h2 class='box'>Anlage zur Sammelbestätigung vom {$issued_on|crmDate:'%d.%m.%Y'} für {$contributor.display_name}</h2>
 <table>
   <tr><th>Datum der Zuwendung</th><th>Art der Zuwendung</th><th>Verzicht auf die Erstattung von Aufwendungen</th><th>Betrag</th></tr>
   {foreach from=$items item=item}


### PR DESCRIPTION
As discussed [here](https://github.com/systopia/de.systopia.donrec/issues/169), the `issued_on` field should not be overwritten when copying a donation receipt. This ensures that a copy bears the correct and original date of its issuance. 

Apart from preserving the original `issued_on` date this PR also adjusts the default template to use the `$issued_on` variable instead of `$today`. Otherwise the change wouldn't have any effect.

> [!IMPORTANT]
> If you are using a custom donation receipt template, you will need to make the above adjustments yourself! You can edit your templates within the **Donation Receipts Profiles** (_Administer -> Administration Console -> Donation Receipts Profiles -> edit_). Find **all** `$today` variables and simply replace them with `$issued_on`.

fix #169 