### PR TITLE
Fix `array_multisort` error

### DIFF
--- a/CRM/Donrec/Logic/ReceiptTokens.php
+++ b/CRM/Donrec/Logic/ReceiptTokens.php
@@ -185,7 +185,7 @@ abstract class CRM_Donrec_Logic_ReceiptTokens {
 
     // sort contribution lines by receive date (#1497)
     $receive_dates = array();
-    $sorted_lines = $values['lines'];
+    $sorted_lines = $values['lines'] ?? [];
     foreach ($sorted_lines as $key => $line) {
       $sorted_lines[$key]['id'] = $key;
       $receive_dates[$key] = $line['receive_date'];


### PR DESCRIPTION
When opening the *Donation Receipts* tab on the contact summary, there might be an error due to missing variable initialisation with a default value.