### PR TITLE
Use `addDatePickerRange` instead of deprecated/removed `addDateRange()` for forms

### DIFF
--- a/CRM/Donrec/Form/Task/ContributeTask.php
+++ b/CRM/Donrec/Form/Task/ContributeTask.php
@@ -30,8 +30,17 @@ class CRM_Donrec_Form_Task_ContributeTask extends CRM_Contribute_Form_Task {
        'last_year'         => E::ts('last year'),
        'customized_period' => E::ts('Choose Date Range')
     );
-    $this->addElement('select', 'time_period', 'Time Period:', $options, array('class' => 'crm-select2'));
-    $this->addDateRange('donrec_contribution_horizon', '_from', '_to', E::ts('From:'), 'searchDate', TRUE, FALSE);
+    $this->addDatePickerRange(
+      'donrec_contribution_horizon',
+      E::ts('Time period'),
+      FALSE,
+      FALSE,
+      E::ts('From:'),
+      E::ts('To:'),
+      [],
+      '_to',
+      '_from',
+    );
 
     // add profile selector
     $this->addElement('select',

--- a/CRM/Donrec/Form/Task/Create.php
+++ b/CRM/Donrec/Form/Task/Create.php
@@ -31,12 +31,21 @@ class CRM_Donrec_Form_Task_Create extends CRM_Core_Form {
        'last_year'         => E::ts('last year'),
        'customized_period' => E::ts('Choose Date Range')
     );
-    $this->addElement('select', 'time_period', 'Time Period:', $options, array('class' => 'crm-select2'));
-    $this->addDateRange('donrec_contribution_horizon', '_from', '_to', E::ts('From:'), 'searchDate', TRUE, FALSE);
+    $this->addDatePickerRange(
+      'donrec_contribution_horizon',
+      E::ts('Time period'),
+      FALSE,
+      FALSE,
+      E::ts('From:'),
+      E::ts('To:'),
+      [],
+      '_to',
+      '_from',
+    );
 
     // add profile selector
-    $this->addElement('select', 
-                      'profile', 
+    $this->addElement('select',
+                      'profile',
                       E::ts('Profile'),
                       CRM_Donrec_Logic_Profile::getAllActiveNames('is_default', 'DESC'),
                       array('class' => 'crm-select2'));

--- a/CRM/Donrec/Form/Task/DonrecTask.php
+++ b/CRM/Donrec/Form/Task/DonrecTask.php
@@ -30,8 +30,17 @@ class CRM_Donrec_Form_Task_DonrecTask extends CRM_Contact_Form_Task {
        'last_year'         => E::ts('last year'),
        'customized_period' => E::ts('Choose Date Range')
     );
-    $this->addElement('select', 'time_period', 'Time Period:', $options, array('class' => 'crm-select2'));
-    $this->addDateRange('donrec_contribution_horizon', '_from', '_to', E::ts('From:'), 'searchDate', TRUE, FALSE);
+    $this->addDatePickerRange(
+      'donrec_contribution_horizon',
+      E::ts('Time Period'),
+      FALSE,
+      FALSE,
+      E::ts('From:'),
+      E::ts('To:'),
+      [],
+      '_to',
+      '_from',
+    );
 
     // add profile selector
     $this->addElement('select',

--- a/CRM/Donrec/Logic/Selector.php
+++ b/CRM/Donrec/Logic/Selector.php
@@ -23,12 +23,22 @@ class CRM_Donrec_Logic_Selector {
    *   creation result/error
    */
   public static function createSnapshot($values) {
+    // Process date picker values.
+    [
+      $values['donrec_contribution_horizon_from'],
+      $values['donrec_contribution_horizon_to']
+    ] = CRM_Utils_Date::getFromTo(
+      $values['donrec_contribution_horizon_relative'],
+      $values['donrec_contribution_horizon_from'],
+      $values['donrec_contribution_horizon_to']
+    );
+
     // prepare timestamps
     $raw_from_ts = $values['donrec_contribution_horizon_from'];
     $raw_to_ts = $values['donrec_contribution_horizon_to'];
 
-    $date_from = CRM_Utils_DonrecHelper::convertDate($raw_from_ts, -1);
-    $date_to = CRM_Utils_DonrecHelper::convertDate($raw_to_ts, 1);
+    $date_from = CRM_Utils_DonrecHelper::convertDate($raw_from_ts, -1, 'YmdHis');
+    $date_to = CRM_Utils_DonrecHelper::convertDate($raw_to_ts, 1, 'YmdHis');
 
     $formatted_date_from = date('Y-m-d H:i:s', $date_from);
     $formatted_date_to = date('Y-m-d H:i:s', $date_to);

--- a/templates/CRM/Donrec/Form/Task/creation_parameters.tpl
+++ b/templates/CRM/Donrec/Form/Task/creation_parameters.tpl
@@ -20,21 +20,9 @@
     </tr>
     <tr>
       <td class="label">
-          {$form.time_period.label}
+        {$form.donrec_contribution_horizon_relative.label}
       </td>
-      <td>
-          {$form.time_period.html}
-      </td>
-    </tr>
-    <tr>
-      <td></td>
-      <td class="custom_period">
-          {$form.donrec_contribution_horizon_from.label}
-          {include file="CRM/common/jcalendar.tpl" elementName=donrec_contribution_horizon_from}
-
-          {$form.donrec_contribution_horizon_to.label}
-          {include file="CRM/common/jcalendar.tpl" elementName=donrec_contribution_horizon_to}
-      </td>
+      {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="donrec_contribution_horizon" from="_from" to="_to" colspan=1 hideRelativeLabel=TRUE}
     </tr>
     <tr>
       <td class="label">
@@ -53,50 +41,4 @@
       </td>
     </tr>
   </table>
-
-    {literal}
-      <script type="text/javascript">
-        cj(document).ready(function() {
-          var time_period = cj('#time_period');
-          var custom_period = cj('.custom_period');
-          var current_year = (new Date).getFullYear();
-          var current_month = (new Date).getMonth();
-          var current_day = (new Date).getDate();
-          var from = cj('#donrec_contribution_horizon_from');
-          var to = cj('#donrec_contribution_horizon_to');
-          var from_display = cj("[id^='donrec_contribution_horizon_from_display']");
-          var to_display = cj("[id^='donrec_contribution_horizon_to_display']");
-
-          var set_period = function () {
-            switch (time_period.val()) {
-              case "customized_period":
-                from.val("");
-                from_display.val("");
-                to.val("");
-                to_display.val("");
-                custom_period.show();
-                break;
-              case "current_year":
-                console.log('this_year');
-                from_display.datepicker('setDate', new Date(current_year, 0, 1));
-                to_display.datepicker('setDate', new Date(current_year, current_month, current_day));
-                custom_period.hide();
-                break;
-              case "last_year":
-                console.log('last_year');
-                from_display.datepicker('setDate', new Date(current_year-1, 0, 1));
-                to_display.datepicker('setDate', new Date(current_year-1, 11, 31));
-                custom_period.hide();
-                break;
-            }
-          };
-
-          //evaluate initial value
-          set_period();
-
-          //on change
-          time_period.change(set_period);
-        });
-      </script>
-    {/literal}
 </div>


### PR DESCRIPTION
Fixes #138.

This replaces the custom-built date range selector fields in task forms with `addDatePickerRange()` as suggested by the deprecation notice, making custom JS code for translating custom relative date options into actual date values unnecessary.

This effectively adds all available date range options and uses `CRM_Utils_Date::getFromTo()` for converting relative dates (*previous fiscal year* etc.) into *from* and *to* values to work with the extension's current query building.

Note that the date picker element can apparently not be made `required`, as all sub-fields would be required effectively (`_from`, `_to`, `_relative`). Maybe there should be additional validation for that …?

I'd appreciate some functional review (maybe by @jojowork?) and a code-one (@bjendres?).

*systopia-reference: 23334*