### PR TITLE
Define permissions with label and description

### DIFF
--- a/donrec.php
+++ b/donrec.php
@@ -215,24 +215,22 @@ function donrec_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 }
 
 /**
- * Custom permissions
+ * Implements hook_civicrm_permission().
  */
-function donrec_civicrm_permission(&$permissions)
-{
-    $permissions['view and copy receipts'] = [
-        'label' => E::ts('DonationReceipts: create and withdraw receipts'),
-        'description' => E::ts('Allows access create and withdraw receipts')
-    ];
-
-    $permissions['create and withdraw receipts'] = [
-        'label' => E::ts('DonationReceipts: view and create copies of receipts'),
-        'description' => E::ts('Allows access to view and create copies of receipts')
-    ];
-
-    $permissions['delete receipts'] = [
-        'label' => E::ts('DonationReceipts: delete receipts'),
-        'description' => E::ts('Allows access to delete receipts')
-    ];
+function donrec_civicrm_permission(&$permissions) {
+  $prefix = E::ts('DonationReceipts') . ': ';
+  $permissions['view and copy receipts'] = [
+    'label' => $prefix . E::ts('view and create copies of receipts'),
+    'description' => E::ts('Allows viewing and creating copies of donation receipts.'),
+  ];
+  $permissions['create and withdraw receipts'] = [
+    'label' => $prefix . E::ts('create and withdraw receipts'),
+    'description' => E::ts('Allows creating and withdrawing donation receipts.'),
+  ];
+  $permissions['delete receipts'] = [
+    'label' => $prefix . E::ts('delete receipts'),
+    'description' => E::ts('Allows deleting donation receipts.'),
+  ];
 }
 
 /**

--- a/donrec.php
+++ b/donrec.php
@@ -217,13 +217,23 @@ function donrec_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
 /**
  * Custom permissions
  */
- function donrec_civicrm_permission(&$permissions) {
-  $prefix = E::ts('DonationReceipts') . ': ';
+function donrec_civicrm_permission(&$permissions)
+{
+    $permissions['view and copy receipts'] = [
+        'label' => E::ts('DonationReceipts: create and withdraw receipts'),
+        'description' => E::ts('Allows access create and withdraw receipts')
+    ];
 
-  $permissions['view and copy receipts'] = $prefix . E::ts('view and create copies of receipts');
-  $permissions['create and withdraw receipts'] = $prefix . E::ts('create and withdraw receipts');
-  $permissions['delete receipts'] = $prefix . E::ts('delete receipts');
- }
+    $permissions['create and withdraw receipts'] = [
+        'label' => E::ts('DonationReceipts: view and create copies of receipts'),
+        'description' => E::ts('Allows access to view and create copies of receipts')
+    ];
+
+    $permissions['delete receipts'] = [
+        'label' => E::ts('DonationReceipts: delete receipts'),
+        'description' => E::ts('Allows access to delete receipts')
+    ];
+}
 
 /**
  * Add headers to sent donation receipts


### PR DESCRIPTION
Fixes User deprecated function: Permission e.g.:
```[PHP User Deprecation] Permission 'view and copy receipts' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions at /var/www/vhosts/HOSTNAME/httpdocs/dev/drupal/vendor/civicrm/civicrm-core/CRM/Core/Error.php:1129```

Deprecation warnings since CiviCRM 5.71.0.

_systopia-reference: 24378_
