### PR TITLE
Disable purification of template field that destroys HTML templates

### DIFF
--- a/CRM/Admin/Form/DonrecProfile.php
+++ b/CRM/Admin/Form/DonrecProfile.php
@@ -618,6 +618,12 @@ class CRM_Admin_Form_DonrecProfile extends CRM_Core_Form {
   /**
    * Process the form submission.
    */
+  
+  // Prevent HTML template from being sanitized
+  protected function getFieldsToExcludeFromPurification(): array {
+    return ['template'];
+  } 
+  
   public function postProcess() {
     $session = CRM_Core_Session::singleton();
 

--- a/CRM/Admin/Form/DonrecProfile.php
+++ b/CRM/Admin/Form/DonrecProfile.php
@@ -618,12 +618,16 @@ class CRM_Admin_Form_DonrecProfile extends CRM_Core_Form {
   /**
    * Process the form submission.
    */
-  
-  // Prevent HTML template from being sanitized
+
+  /**
+   * {@inheritDoc}
+   */
   protected function getFieldsToExcludeFromPurification(): array {
+    // Prevent HTML template from being sanitized.
+    // @see \CRM_Core_Form::setPurifiedDefaults()
     return ['template'];
-  } 
-  
+  }
+
   public function postProcess() {
     $session = CRM_Core_Session::singleton();
 


### PR DESCRIPTION
Fix for issue [196](https://github.com/systopia/de.systopia.donrec/issues/196) which led to the destruction of a donation template when edited since CiviCRM 5.72.