### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,11 +8,11 @@
     <author>SYSTOPIA</author>
     <email>info@systopia.de</email>
   </maintainer>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>2.4.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.60</ver>
+    <ver>5.65</ver>
   </compatibility>
   <urls>
     <url desc="Main Extension Page">https://github.com/systopia/de.systopia.donrec</url>

--- a/templates/CRM/Admin/Form/DonrecProfile.tpl
+++ b/templates/CRM/Admin/Form/DonrecProfile.tpl
@@ -89,44 +89,44 @@
             </tr>
 
             <tr class="crm-donrec-profile-form-block-language">
-              <td class="label">{$form.language.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Languages{/ts}", {literal}{"id":"id-language","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.language.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Languages{/ts}", {literal}{"id":"id-language","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.language.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-enable_encryption">
-              <td class="label">{$form.enable_encryption.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Enable encryption{/ts}", {literal}{"id":"id-enable_encryption","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.enable_encryption.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Enable encryption{/ts}", {literal}{"id":"id-enable_encryption","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.enable_encryption.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-financial_types">
-              <td class="label">{$form.financial_types.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Contribution Types{/ts}", {literal}{"id":"id-contribution-types","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.financial_types.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Contribution Types{/ts}", {literal}{"id":"id-contribution-types","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.financial_types.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-id_pattern">
-              <td class="label">{$form.id_pattern.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Receipt ID{/ts}", {literal}{"id":"id-id_pattern","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.id_pattern.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Receipt ID{/ts}", {literal}{"id":"id-id_pattern","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.id_pattern.html}</td>
             </tr>
 
             <tr><td><h4>{ts domain="de.systopia.donrec"}Address Types{/ts}</h4></td></tr>
 
             <tr class="crm-donrec-profile-form-block-legal_address">
-              <td class="label">{$form.legal_address.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Legal Address{/ts}", {literal}{"id":"id-address-legal","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.legal_address.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Legal Address{/ts}", {literal}{"id":"id-address-legal","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.legal_address.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-legal_address_fallback">
-              <td class="label">{$form.legal_address_fallback.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Legal Address Fallback{/ts}", {literal}{"id":"id-address-fallback","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.legal_address_fallback.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Legal Address Fallback{/ts}", {literal}{"id":"id-address-fallback","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.legal_address_fallback.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-postal_address">
-              <td class="label">{$form.postal_address.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Postal Address{/ts}", {literal}{"id":"id-address-shipping","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.postal_address.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Postal Address{/ts}", {literal}{"id":"id-address-shipping","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.postal_address.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-postal_address_fallback">
-              <td class="label">{$form.postal_address_fallback.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Postal Address Fallback{/ts}", {literal}{"id":"id-address-fallback","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.postal_address_fallback.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Postal Address Fallback{/ts}", {literal}{"id":"id-address-fallback","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.postal_address_fallback.html}</td>
             </tr>
 
@@ -141,17 +141,17 @@
           <table class="form-layout">
 
             <tr class="crm-donrec-profile-form-block-template">
-              <td class="label"><label for="template">{$form.template.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Template{/ts}", {literal}{"id":"id-template","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
+              <td class="label"><label for="template">{$form.template.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Template{/ts}", {literal}{"id":"id-template","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
               <td>{$form.template.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-template_pdf_format_id">
-              <td class="label"><label for="template_pdf_format_id">{$form.template_pdf_format_id.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}PDF format{/ts}", {literal}{"id":"id-template_pdf_format_id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
+              <td class="label"><label for="template_pdf_format_id">{$form.template_pdf_format_id.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}PDF format{/ts}", {literal}{"id":"id-template_pdf_format_id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></label></td>
               <td>{$form.template_pdf_format_id.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-variables">
-              <td class="label"><label>{ts domain="de.systopia.donrec"}Variables{/ts}</label> <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Variables{/ts}", {literal}{"id":"id-variables","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label"><label>{ts domain="de.systopia.donrec"}Variables{/ts}</label> <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Variables{/ts}", {literal}{"id":"id-variables","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                 <div id="crm-donrec-profile-form-block-variables-wrapper">
                   {include file='CRM/Admin/Form/DonrecProfile/Variables.tpl'}
@@ -161,7 +161,7 @@
             </tr>
 
             <tr class="crm-donrec-profile-form-block-store_original_pdf">
-              <td class="label">{$form.store_original_pdf.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Store original PDF{/ts}", {literal}{"id":"id-store_original_pdf","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.store_original_pdf.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Store original PDF{/ts}", {literal}{"id":"id-store_original_pdf","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.store_original_pdf.html}</td>
             </tr>
 
@@ -170,17 +170,17 @@
             </tr>
 
             <tr class="crm-donrec-profile-form-block-draft_text">
-              <td class="label">{$form.draft_text.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Draft Text{/ts}", {literal}{"id":"id-draft-text","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.draft_text.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Draft Text{/ts}", {literal}{"id":"id-draft-text","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.draft_text.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-copy_text">
-              <td class="label">{$form.copy_text.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Copy Text{/ts}", {literal}{"id":"id-copy-text","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.copy_text.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Copy Text{/ts}", {literal}{"id":"id-copy-text","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.copy_text.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-watermark_preset">
-              <td class="label">{$form.watermark_preset.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Watermark preset{/ts}", {literal}{"id":"id-watermark-preset","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.watermark_preset.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Watermark preset{/ts}", {literal}{"id":"id-watermark-preset","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.watermark_preset.html}</td>
             </tr>
 
@@ -201,52 +201,52 @@
           <table class="form-layout">
 
             <tr class="crm-donrec-profile-form-block-email_template">
-              <td class="label">{$form.email_template.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Email-Template{/ts}", {literal}{"id":"id-email-template","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.email_template.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Email-Template{/ts}", {literal}{"id":"id-email-template","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.email_template.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-from_email">
-              <td class="label">{$form.from_email.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}From Email Address{/ts}", {literal}{"id":"id-from-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.from_email.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}From Email Address{/ts}", {literal}{"id":"id-from-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.from_email.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-bcc_email">
-              <td class="label">{$form.bcc_email.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}BCC Email Address{/ts}", {literal}{"id":"id-bcc-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.bcc_email.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}BCC Email Address{/ts}", {literal}{"id":"id-bcc-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.bcc_email.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-return_path_email">
-              <td class="label">{$form.return_path_email.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Return Path Email Address{/ts}", {literal}{"id":"id-return-path-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.return_path_email.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Return Path Email Address{/ts}", {literal}{"id":"id-return-path-email","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.return_path_email.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_handling">
-              <td class="label">{$form.special_mail_handling.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Custom Mail handling{/ts}", {literal}{"id":"id-special-mail-handling","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_handling.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Custom Mail handling{/ts}", {literal}{"id":"id-special-mail-handling","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_handling.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_header">
-              <td class="label">{$form.special_mail_header.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-header","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_header.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-header","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_header.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_header">
-              <td class="label">{$form.special_mail_activity_id.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-activity-id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_activity_id.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-activity-id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_activity_id.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_header">
-              <td class="label">{$form.special_mail_activity_subject.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-activity-subject","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_activity_subject.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Custom Mail Header{/ts}", {literal}{"id":"id-special-mail-activity-subject","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_activity_subject.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_header">
-              <td class="label">{$form.special_mail_activity_contact_id.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Activity Contact Id{/ts}", {literal}{"id":"id-special-mail-activity-contact-id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_activity_contact_id.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Activity Contact Id{/ts}", {literal}{"id":"id-special-mail-activity-contact-id","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_activity_contact_id.html}</td>
             </tr>
 
             <tr class="crm-donrec-profile-form-block-special_mail_header">
-              <td class="label">{$form.special_mail_withdraw_receipt.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Withdraw Receipt{/ts}", {literal}{"id":"id-special-mail-withdraw-receipt","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.special_mail_withdraw_receipt.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Withdraw Receipt{/ts}", {literal}{"id":"id-special-mail-withdraw-receipt","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>{$form.special_mail_withdraw_receipt.html}</td>
             </tr>
           </table>
@@ -260,7 +260,7 @@
           <table class="form-layout">
 
             <tr class="crm-donrec-profile-form-block-contribution_unlock_mode">
-              <td class="label">{$form.contribution_unlock_mode.label} <a onclick='CRM.help("{ts domain="de.systopia.donrec"}Unlock receipted contributions{/ts}", {literal}{"id":"id-contribution_unlock_mode","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
+              <td class="label">{$form.contribution_unlock_mode.label} <a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Unlock receipted contributions{/ts}", {literal}{"id":"id-contribution_unlock_mode","file":"CRM\/Admin\/Form\/DonrecProfile"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}" class="helpicon">&nbsp;</a></td>
               <td>
                   {$form.contribution_unlock_mode.html}
                 <fieldset id="contribution_unlock_fields">

--- a/templates/CRM/Admin/Form/Setting/DonrecSettings.tpl
+++ b/templates/CRM/Admin/Form/Setting/DonrecSettings.tpl
@@ -18,23 +18,23 @@
 
       <tr class="crm-donrec-profile-form-block-enable_line_item">
         <td class="label">{$form.enable_line_item.label} <a
-            onclick='CRM.help("{ts domain="de.systopia.donrec"}Enable line item{/ts}", {literal}{"id":"id-enable-line-item","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
-            href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}"
+            onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Enable line item{/ts}", {literal}{"id":"id-enable-line-item","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
+            href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}"
             class="helpicon">&nbsp;</a></td>
         <td>{$form.enable_line_item.html}</td>
       </tr>
 
       <tr class="crm-donrec-profile-form-block-packet_size">
         <td class="label">{$form.packet_size.label} <a
-                  onclick='CRM.help("{ts domain="de.systopia.donrec"}Generator Packet Size{/ts}", {literal}{"id":"id-packet-size","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
-                  href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}"
+                  onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}Generator Packet Size{/ts}", {literal}{"id":"id-packet-size","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
+                  href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}"
                   class="helpicon">&nbsp;</a></td>
         <td>{$form.packet_size.html}</td>
       </tr>
 
       <tr class="crm-donrec-profile-form-block-pdfinfo_path">
         <td class="label">{$form.pdfinfo_path.label} <a
-                  onclick='CRM.help("{ts domain="de.systopia.donrec"}The <code>pdfinfo</code> Tool{/ts}", {literal}{"id":"id-pdfinfo-text","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
+                  onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}The <code>pdfinfo</code> Tool{/ts}", {literal}{"id":"id-pdfinfo-text","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
                   href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}"
                   class="helpicon">&nbsp;</a></td>
         <td>{$form.pdfinfo_path.html}</td>
@@ -42,7 +42,7 @@
 
       <tr class="crm-donrec-profile-form-block-pdfunite_path">
         <td class="label">{$form.pdfunite_path.label} <a
-                  onclick='CRM.help("{ts domain="de.systopia.donrec"}The <code>pdfunite</code> Tool{/ts}", {literal}{"id":"id-pdfunite-text","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
+                  onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}The <code>pdfunite</code> Tool{/ts}", {literal}{"id":"id-pdfunite-text","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
                   href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}"
                   class="helpicon">&nbsp;</a></td>
         <td>{$form.pdfunite_path.html}</td>
@@ -50,8 +50,8 @@
 
       <tr class="crm-donrec-encryption-command">
         <td class="label">{$form.encryption_command.label} <a
-                  onclick='CRM.help("{ts domain="de.systopia.donrec"}External Tool: command line for encryption{/ts}", {literal}{"id":"id-encryption-command","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
-                  href="#" title="{ts domain="de.systopia.donrec"}Help{/ts}"
+                  onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.donrec"}External Tool: command line for encryption{/ts}", {literal}{"id":"id-encryption-command","file":"CRM\/Admin\/Form\/Setting\/DonrecSettings"}{/literal}); return false;'
+                  href="#" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Help{/ts}"
                   class="helpicon">&nbsp;</a></td>
         <td>{$form.encryption_command.html}</td>
       </tr>

--- a/templates/CRM/Admin/Page/DonrecProfiles.tpl
+++ b/templates/CRM/Admin/Page/DonrecProfiles.tpl
@@ -11,11 +11,11 @@
 
   <div class="crm-submit-buttons">
 
-    <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=create"}" title="{ts domain="de.systopia.donrec"}New profile{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=create"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}New profile{/ts}" class="button">
       <span><i class="crm-i fa-plus-circle"></i> {ts domain="de.systopia.donrec"}New profile{/ts}</span>
     </a>
 
-    <a href="{crmURL p="civicrm/admin/setting/donrec" q="reset=1"}" title="{ts domain="de.systopia.donrec"}Manage general extension settings{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/setting/donrec" q="reset=1"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Manage general extension settings{/ts}" class="button">
       <span><i class="crm-i fa-cog"></i> {ts domain="de.systopia.donrec"}General settings{/ts}</span>
     </a>
 
@@ -37,10 +37,10 @@
               {if $sort == 'id'}
                   {if $sort_id_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -53,10 +53,10 @@
               {if $sort == 'name'}
                   {if $sort_name_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -69,10 +69,10 @@
               {if $sort == 'is_default'}
                   {if $sort_is_default_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -85,10 +85,10 @@
               {if $sort == 'is_active'}
                   {if $sort_is_active_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -101,10 +101,10 @@
               {if $sort == 'is_locked'}
                   {if $sort_is_locked_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -117,10 +117,10 @@
               {if $sort == 'usage_count'}
                   {if $sort_usage_count_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -133,10 +133,10 @@
               {if $sort == 'first_used_date'}
                   {if $sort_first_used_date_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -149,10 +149,10 @@
               {if $sort == 'last_used_date'}
                   {if $sort_last_used_date_desc}
                     <span class="crm-i fa-caret-up"
-                          title="{ts domain="de.systopia.donrec"}Sort descending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort descending{/ts}"></span>
                   {else}
                     <span class="crm-i fa-caret-down"
-                          title="{ts domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
+                          title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Sort ascending{/ts}"></span>
                   {/if}
               {/if}
           </a>
@@ -172,21 +172,21 @@
 
           <td>{$profile.name}</td>
 
-          <td class="center">{if $profile.is_default}<span class="crm-i fa-check" title="{ts domain="de.systopia.donrec"}Default{/ts}"></span>{/if}</td>
+          <td class="center">{if $profile.is_default}<span class="crm-i fa-check" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Default{/ts}"></span>{/if}</td>
 
           <td class="center">
             {if $profile.is_active}
-              <span class="crm-i fa-check" title="{ts domain="de.systopia.donrec"}Active{/ts}"></span>
+              <span class="crm-i fa-check" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Active{/ts}"></span>
             {else}
-              <span class="crm-i fa-ban" title="{ts domain="de.systopia.donrec"}Inactive{/ts}"></span>
+              <span class="crm-i fa-ban" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Inactive{/ts}"></span>
             {/if}
           </td>
 
           <td class="center">
             {if $profile.is_locked}
-              <span class="crm-i fa-lock" title="{ts domain="de.systopia.donrec"}Locked{/ts}"></span>
+              <span class="crm-i fa-lock" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Locked{/ts}"></span>
             {else}
-              <span class="crm-i fa-unlock" title="{ts domain="de.systopia.donrec"}Unlocked{/ts}"></span>
+              <span class="crm-i fa-unlock" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Unlocked{/ts}"></span>
             {/if}
           </td>
 
@@ -197,18 +197,18 @@
           <td>{$profile.last_used}</td>
 
           <td>
-            <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=edit&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Edit{/ts}</a>
-            <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=copy&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Copy{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=edit&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Edit{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=copy&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Copy{/ts}</a>
             {if !$profile.is_active}
-              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=activate&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Activate profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Activate{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=activate&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Activate profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Activate{/ts}</a>
             {else}
-              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=deactivate&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Deactivate profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Deactivate{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=deactivate&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Deactivate profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Deactivate{/ts}</a>
             {/if}
             {if !$profile.is_default}
-              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=default&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Set profile %1 as default{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Set default{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=default&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Set profile %1 as default{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Set default{/ts}</a>
             {/if}
             {if !$profile.is_locked}
-              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=delete&id=$profile_id"}" title="{ts domain="de.systopia.donrec" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Delete{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/setting/donrec/profile" q="op=delete&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.donrec" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.donrec"}Delete{/ts}</a>
             {/if}
           </td>
 

--- a/templates/CRM/Donrec/Page/Tab.tpl
+++ b/templates/CRM/Donrec/Page/Tab.tpl
@@ -80,18 +80,18 @@
         {/if}
 
         {*ALTERNATIVELY: CiviCRM List style: if $receipt.original_file}
-          <a id="view_receipt_{$receipt_id}" title="{ts domain="de.systopia.donrec"}View{/ts}" class="action-item action-item-first" href="{$receipt.original_file}">{ts domain="de.systopia.donrec"}View{/ts}</a>
+          <a id="view_receipt_{$receipt_id}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}View{/ts}" class="action-item action-item-first" href="{$receipt.original_file}">{ts domain="de.systopia.donrec"}View{/ts}</a>
         {else}
-          <a id="view_receipt_{$receipt_id}" title="{ts domain="de.systopia.donrec"}View{/ts}" class="action-item action-item-first" href="#">{ts domain="de.systopia.donrec"}View{/ts}</a>
+          <a id="view_receipt_{$receipt_id}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}View{/ts}" class="action-item action-item-first" href="#">{ts domain="de.systopia.donrec"}View{/ts}</a>
         {/if}
         {if $receipt.status == 'ORIGINAL' && $can_view_copy}
-          <a id="copy_receipt_{$receipt_id}" title="{ts domain="de.systopia.donrec"}Create copy{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Create copy{/ts}</a>
+          <a id="copy_receipt_{$receipt_id}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Create copy{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Create copy{/ts}</a>
         {/if}
         {if $can_create_withdraw}
-          <a id="withdraw_receipt_{$receipt_id}" title="{ts domain="de.systopia.donrec"}Withdraw{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Withdraw{/ts}</a>
+          <a id="withdraw_receipt_{$receipt_id}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Withdraw{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Withdraw{/ts}</a>
         {/if}
         {if $can_delete}
-          <a id="delete_receipt_{$receipt_id}" title="{ts domain="de.systopia.donrec"}Delete{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Delete{/ts}</a>
+          <a id="delete_receipt_{$receipt_id}" title="{ts escape='htmlattribute' domain="de.systopia.donrec"}Delete{/ts}" class="action-item" href="#">{ts domain="de.systopia.donrec"}Delete{/ts}</a>
         {/if*}
       </td>
     </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.