### PR TITLE
Refresh list of receipts after creating copy without showing a print dialog

### DIFF
--- a/templates/CRM/Donrec/Page/Tab.tpl
+++ b/templates/CRM/Donrec/Page/Tab.tpl
@@ -313,7 +313,7 @@
                 if (data['is_error'] == 0) {
                   CRM.alert("{/literal}{ts domain="de.systopia.donrec"}The donation receipt has been successfully copied{/ts}", "{ts domain="de.systopia.donrec"}Success{/ts}{literal}", "success");
                   var contentId = cj('#tab_donation_receipts').attr('aria-controls');
-                  cj('#' + contentId).load(CRM.url('civicrm/donrec/tab', {'reset': 1, 'snippet': 1, 'force': 1, 'cid':{/literal}{$cid}{literal}}));
+                  CRM.refreshParent('#' + contentId)
                 }else{
                   CRM.alert("{/literal}" + data['error_message'], "{ts domain="de.systopia.donrec"}Error{/ts}{literal}", "error");
                 }


### PR DESCRIPTION
Use `CRM.refreshParent()` for reloading the list of receipts.

`snippet: 1` in the current implementation causes the print dialog to open.

*systopia-reference: 30542*