### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Donrec/CustomData.php
+++ b/CRM/Donrec/CustomData.php
@@ -735,7 +735,7 @@ class CRM_Donrec_CustomData {
         return $field_data['value'];
       } else {
         // unlikely, but worth a shot:
-        return CRM_Utils_Array::value("custom_{$field_id}", $params, NULL);
+        return $params["custom_{$field_id}"] ?? NULL;
       }
     }
     return NULL;
@@ -785,9 +785,9 @@ class CRM_Donrec_CustomData {
         'value'           => $value,
         'type'            => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
         'custom_field_id' => $field_id,
-        'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, NULL),
-        'table_name'      => CRM_Utils_Array::value('table_name', $group_specs, NULL),
-        'column_name'     => CRM_Utils_Array::value('column_name', $field_specs, NULL),
+        'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+        'table_name'      => $group_specs['table_name'] ?? NULL,
+        'column_name'     => $field_specs['column_name'] ?? NULL,
         'is_multiple'     => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
       ];
     } else {

--- a/CRM/Donrec/Exporters/EmailPDF.php
+++ b/CRM/Donrec/Exporters/EmailPDF.php
@@ -166,7 +166,7 @@ class CRM_Donrec_Exporters_EmailPDF extends CRM_Donrec_Exporters_EncryptedPDF {
         foreach ($fromEmailAddress as $key => $value) {
           $from_email_address = CRM_Utils_Mail::pluckEmailFromHeader($value);
           $fromArray = explode('"', $value);
-          $from_email_name = CRM_Utils_Array::value(1, $fromArray);
+          $from_email_name = $fromArray[1] ?? NULL;
           break;
         }
       }

--- a/CRM/Donrec/Form/Task/ContributeTask.php
+++ b/CRM/Donrec/Form/Task/ContributeTask.php
@@ -93,7 +93,7 @@ class CRM_Donrec_Form_Task_ContributeTask extends CRM_Contribute_Form_Task {
     if (!empty($rsid)) {
 
       //work on with a remaining snapshot...
-      $use_remaining_snapshot = CRM_Utils_Array::value('use_remaining_snapshot', $_REQUEST, NULL);
+      $use_remaining_snapshot = $_REQUEST['use_remaining_snapshot'] ?? NULL;
       if (!empty($use_remaining_snapshot)) {
         CRM_Core_Session::singleton()->pushUserContext(
           CRM_Utils_System::url('civicrm/donrec/task', 'sid=' . $rsid)

--- a/CRM/Donrec/Form/Task/Create.php
+++ b/CRM/Donrec/Form/Task/Create.php
@@ -97,7 +97,7 @@ class CRM_Donrec_Form_Task_Create extends CRM_Core_Form {
     if (!empty($rsid)) {
 
       //work on with a remaining snapshot...
-      $use_remaining_snapshot = CRM_Utils_Array::value('use_remaining_snapshot', $_REQUEST, NULL);
+      $use_remaining_snapshot = $_REQUEST['use_remaining_snapshot'] ?? NULL;
       if (!empty($use_remaining_snapshot)) {
         CRM_Core_Session::singleton()->pushUserContext(
           CRM_Utils_System::url('civicrm/donrec/task', 'sid=' . $rsid)

--- a/CRM/Donrec/Form/Task/DonrecTask.php
+++ b/CRM/Donrec/Form/Task/DonrecTask.php
@@ -93,7 +93,7 @@ class CRM_Donrec_Form_Task_DonrecTask extends CRM_Contact_Form_Task {
     if (!empty($rsid)) {
 
       //work on with a remaining snapshot...
-      $use_remaining_snapshot = CRM_Utils_Array::value('use_remaining_snapshot', $_REQUEST, NULL);
+      $use_remaining_snapshot = $_REQUEST['use_remaining_snapshot'] ?? NULL;
       if (!empty($use_remaining_snapshot)) {
         CRM_Core_Session::singleton()->pushUserContext(
           CRM_Utils_System::url('civicrm/donrec/task', 'sid=' . $rsid)

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -369,7 +369,7 @@ class CRM_Donrec_Logic_Profile {
    *   The value of the profile data property.
    */
   public function getDataAttribute($key) {
-    return CRM_Utils_Array::value($key, $this->data, NULL);
+    return $this->data[$key] ?? NULL;
   }
 
   /**


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.