### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Donrec/Exporters/EmailPDF.php
+++ b/CRM/Donrec/Exporters/EmailPDF.php
@@ -75,7 +75,7 @@ class CRM_Donrec_Exporters_EmailPDF extends CRM_Donrec_Exporters_EncryptedPDF {
    * @param bool $is_test
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function postprocessPDF($file, $snapshot_receipt, $is_test) {
     // encrypt file if configured in profile

--- a/CRM/Donrec/Exporters/GroupedPDF.php
+++ b/CRM/Donrec/Exporters/GroupedPDF.php
@@ -198,7 +198,7 @@ class CRM_Donrec_Exporters_GroupedPDF extends CRM_Donrec_Exporters_EncryptedPDF 
    * @param string $document
    *
    * @return int page count (-1 if there is an error)
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   private function getPDFPageCount($document)
   {

--- a/CRM/Donrec/Form/Task/DonrecResetTask.php
+++ b/CRM/Donrec/Form/Task/DonrecResetTask.php
@@ -69,7 +69,7 @@ class CRM_Donrec_Form_Task_DonrecResetTask extends CRM_Contact_Form_Task {
         try {
           civicrm_api3('DonationReceipt', 'withdraw', ['rid' => $receipt_query->receipt_id]);
           $success_counter += 1;
-        } catch(CiviCRM_API3_Exception $ex) {
+        } catch(CRM_Core_Exception $ex) {
           $error_counter += 1;
         }
       }

--- a/CRM/Donrec/Logic/Engine.php
+++ b/CRM/Donrec/Logic/Engine.php
@@ -47,7 +47,7 @@ class CRM_Donrec_Logic_Engine {
    * @param bool $testMode
    *
    * @return string with an error message on fail, FALSE otherwise
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function init($snapshot_id, $params=array(), $testMode = FALSE) {
     $this->parameters = $params;

--- a/CRM/Donrec/Logic/Settings.php
+++ b/CRM/Donrec/Logic/Settings.php
@@ -25,7 +25,7 @@ class CRM_Donrec_Logic_Settings {
    * @param string $name
    *
    * @return array|string
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function get($name) {
     return civicrm_api3('Setting', 'getvalue', array('name' => $name));
@@ -35,7 +35,7 @@ class CRM_Donrec_Logic_Settings {
    * generic set setting
    * @param string $name
    * @param mixed $value
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
 */
   public static function set($name, $value) {
     civicrm_api3('Setting', 'create', array($name => $value));

--- a/api/v3/DonationReceipt/Handlebounce.php
+++ b/api/v3/DonationReceipt/Handlebounce.php
@@ -37,7 +37,7 @@ function _civicrm_api3_donation_receipt_Handlebounce_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_donation_receipt_Handlebounce($params) {
   $config_data = get_config_data($params['profile_id']);

--- a/api/v3/DonationReceiptEngine/Next.php
+++ b/api/v3/DonationReceiptEngine/Next.php
@@ -16,7 +16,7 @@ use CRM_Donrec_ExtensionUtil as E;
  * @param array $params
  *
  * @return array
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_donation_receipt_engine_next($params) {
   // first, check if the snapshot ID is there


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.