### PR TITLE
Do not declare table_name in custom group managed entities

### DIFF
--- a/managed/CustomGroup_zwb_donation_receipt.mgd.php
+++ b/managed/CustomGroup_zwb_donation_receipt.mgd.php
@@ -11,7 +11,6 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'zwb_donation_receipt',
-        'table_name' => 'civicrm_value_zwb_donation_receipt',
         'title' => E::ts('Donation Receipt'),
         // '0' to prevent from being shown in the contact dashboard (#2541).
         'style' => '0',

--- a/managed/CustomGroup_zwb_donation_receipt_item.mgd.php
+++ b/managed/CustomGroup_zwb_donation_receipt_item.mgd.php
@@ -11,7 +11,6 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'zwb_donation_receipt_item',
-        'table_name' => 'civicrm_value_zwb_donation_receipt_item',
         'title' => E::ts('Donation Receipt Item'),
         'extends' => 'Contribution',
         // '0' to prevent from being shown in the contact dashboard (#2541).


### PR DESCRIPTION
The explicit `table_name` (introduced with the managed-entity migration in #235) causes managed reconciliation to overwrite the metadata of existing custom groups without renaming the physical tables, breaking all installations upgrading from 2.3.x ("DB Error: no such table"). The legacy table name cannot be derived since auto-generated names vary by core version and install locale. See #237 for details and a manual repair guide. Note: installations already broken by 2.4.0 still need a repair step.