### PR TITLE
Normalize Donrec custom table names on install

### DIFF
--- a/donrec.php
+++ b/donrec.php
@@ -65,7 +65,11 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
       'name' => $groupName,
     ]);
   }
-  catch (CiviCRM_API3_Exception $exception) {
+  catch (Exception $exception) {
+    return;
+  }
+
+  if (!is_array($customGroup) || !isset($customGroup['id'], $customGroup['table_name'])) {
     return;
   }
 
@@ -74,7 +78,12 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
     return;
   }
 
-  $expectedTableName = $tableNamePrefix . '_' . (int) $customGroup['id'];
+  $customGroupId = (int) $customGroup['id'];
+  if ($customGroupId <= 0) {
+    return;
+  }
+
+  $expectedTableName = $tableNamePrefix . '_' . $customGroupId;
   if ($currentTableName === $expectedTableName) {
     return;
   }
@@ -85,15 +94,15 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
     throw new CRM_Core_Exception("Unsafe Donrec custom table name for {$groupName}.");
   }
 
-  $currentTableExists = CRM_Core_DAO::checkTableExists($currentTableName);
-  $expectedTableExists = CRM_Core_DAO::checkTableExists($expectedTableName);
+  $currentTableExists = CRM_Core_DAO::checkTableExists($currentTableName) !== FALSE;
+  $expectedTableExists = CRM_Core_DAO::checkTableExists($expectedTableName) !== FALSE;
 
   if (!$currentTableExists && $expectedTableExists) {
     CRM_Core_DAO::executeQuery(
       'UPDATE `civicrm_custom_group` SET `table_name` = %1 WHERE `id` = %2',
       [
         1 => [$expectedTableName, 'String'],
-        2 => [(int) $customGroup['id'], 'Integer'],
+        2 => [$customGroupId, 'Integer'],
       ]
     );
     return;
@@ -105,7 +114,7 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
       'UPDATE `civicrm_custom_group` SET `table_name` = %1 WHERE `id` = %2',
       [
         1 => [$expectedTableName, 'String'],
-        2 => [(int) $customGroup['id'], 'Integer'],
+        2 => [$customGroupId, 'Integer'],
       ]
     );
     return;

--- a/donrec.php
+++ b/donrec.php
@@ -70,7 +70,7 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
     return;
   }
 
-  $customGroupId = (int) $customGroup['id'];
+  $customGroupId = $customGroup['id'];
   if ($customGroupId <= 0) {
     return;
   }
@@ -80,8 +80,8 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
     return;
   }
 
-  if (!preg_match('/^[A-Za-z0-9_]+$/', $currentTableName)
-    || !preg_match('/^[A-Za-z0-9_]+$/', $expectedTableName)
+  if (preg_match('/^[A-Za-z0-9_]+$/', $currentTableName) !== 1
+    || preg_match('/^[A-Za-z0-9_]+$/', $expectedTableName) !== 1
   ) {
     throw new CRM_Core_Exception("Unsafe Donrec custom table name for {$groupName}.");
   }
@@ -102,7 +102,7 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
 /**
  * Look up a custom group that may need install-time table normalization.
  *
- * @return array<string, mixed>|null
+ * @return array{id: int, table_name: string}|null
  */
 function _donrec_civicrm_get_custom_group_for_normalization(string $groupName): ?array {
   try {
@@ -119,15 +119,21 @@ function _donrec_civicrm_get_custom_group_for_normalization(string $groupName): 
     return NULL;
   }
 
-  return $customGroup;
+  if (!is_numeric($customGroup['id']) || (int) $customGroup['id'] <= 0 || !is_string($customGroup['table_name'])) {
+    return NULL;
+  }
+
+  return [
+    'id' => (int) $customGroup['id'],
+    'table_name' => $customGroup['table_name'],
+  ];
 }
 
 /**
  * Check whether the given table exists.
  */
 function _donrec_civicrm_table_exists(string $tableName): bool {
-  $tableExists = CRM_Core_DAO::checkTableExists($tableName);
-  return $tableExists !== FALSE && $tableExists > 0;
+  return CRM_Core_DAO::checkTableExists($tableName) !== FALSE;
 }
 
 /**

--- a/donrec.php
+++ b/donrec.php
@@ -60,16 +60,8 @@ function _donrec_civicrm_normalize_custom_group_table_names(): void {
  * Rename the managed custom group table to the expected deterministic name.
  */
 function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, string $tableNamePrefix): void {
-  try {
-    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
-      'name' => $groupName,
-    ]);
-  }
-  catch (Exception $exception) {
-    return;
-  }
-
-  if (!is_array($customGroup) || !isset($customGroup['id'], $customGroup['table_name'])) {
+  $customGroup = _donrec_civicrm_get_custom_group_for_normalization($groupName);
+  if ($customGroup === NULL) {
     return;
   }
 
@@ -94,9 +86,61 @@ function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, st
     throw new CRM_Core_Exception("Unsafe Donrec custom table name for {$groupName}.");
   }
 
-  $currentTableExists = CRM_Core_DAO::checkTableExists($currentTableName) !== FALSE;
-  $expectedTableExists = CRM_Core_DAO::checkTableExists($expectedTableName) !== FALSE;
+  $currentTableExists = _donrec_civicrm_table_exists($currentTableName);
+  $expectedTableExists = _donrec_civicrm_table_exists($expectedTableName);
 
+  _donrec_civicrm_apply_custom_group_table_name(
+    $groupName,
+    $customGroupId,
+    $currentTableName,
+    $expectedTableName,
+    $currentTableExists,
+    $expectedTableExists
+  );
+}
+
+/**
+ * Look up a custom group that may need install-time table normalization.
+ *
+ * @return array<string, mixed>|null
+ */
+function _donrec_civicrm_get_custom_group_for_normalization(string $groupName): ?array {
+  try {
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => $groupName,
+    ]);
+  }
+  catch (Exception $exception) {
+    // @ignoreException
+    return NULL;
+  }
+
+  if (!is_array($customGroup) || !isset($customGroup['id'], $customGroup['table_name'])) {
+    return NULL;
+  }
+
+  return $customGroup;
+}
+
+/**
+ * Check whether the given table exists.
+ */
+function _donrec_civicrm_table_exists(string $tableName): bool {
+  $tableExists = CRM_Core_DAO::checkTableExists($tableName);
+  return $tableExists !== FALSE && $tableExists > 0;
+}
+
+/**
+ * Apply the table rename or metadata update based on the detected table state.
+ */
+function _donrec_civicrm_apply_custom_group_table_name(
+  string $groupName,
+  int $customGroupId,
+  string $currentTableName,
+  string $expectedTableName,
+  bool $currentTableExists,
+  bool $expectedTableExists
+): void {
   if (!$currentTableExists && $expectedTableExists) {
     CRM_Core_DAO::executeQuery(
       'UPDATE `civicrm_custom_group` SET `table_name` = %1 WHERE `id` = %2',

--- a/donrec.php
+++ b/donrec.php
@@ -28,6 +28,7 @@ function donrec_civicrm_config(\CRM_Core_Config $config): void {
  */
 function donrec_civicrm_install(): void {
   _donrec_civix_civicrm_install();
+  _donrec_civicrm_normalize_custom_group_table_names();
 }
 
 /**
@@ -35,6 +36,88 @@ function donrec_civicrm_install(): void {
  */
 function donrec_civicrm_enable(): void {
   _donrec_civix_civicrm_enable();
+  _donrec_civicrm_normalize_custom_group_table_names();
+}
+
+/**
+ * Normalize Donrec custom group table names after install/enable.
+ *
+ * This is a one-time compatibility shim for clean installs where CiviCRM
+ * derives table names from translated titles instead of stable technical names.
+ */
+function _donrec_civicrm_normalize_custom_group_table_names(): void {
+  $customGroups = [
+    'zwb_donation_receipt' => 'civicrm_value_donation_receipt',
+    'zwb_donation_receipt_item' => 'civicrm_value_donation_receipt_item',
+  ];
+
+  foreach ($customGroups as $groupName => $tableNamePrefix) {
+    _donrec_civicrm_normalize_custom_group_table_name($groupName, $tableNamePrefix);
+  }
+}
+
+/**
+ * Rename the managed custom group table to the expected deterministic name.
+ */
+function _donrec_civicrm_normalize_custom_group_table_name(string $groupName, string $tableNamePrefix): void {
+  try {
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => $groupName,
+    ]);
+  }
+  catch (CiviCRM_API3_Exception $exception) {
+    return;
+  }
+
+  $currentTableName = $customGroup['table_name'] ?? NULL;
+  if (!is_string($currentTableName) || $currentTableName === '') {
+    return;
+  }
+
+  $expectedTableName = $tableNamePrefix . '_' . (int) $customGroup['id'];
+  if ($currentTableName === $expectedTableName) {
+    return;
+  }
+
+  if (!preg_match('/^[A-Za-z0-9_]+$/', $currentTableName)
+    || !preg_match('/^[A-Za-z0-9_]+$/', $expectedTableName)
+  ) {
+    throw new CRM_Core_Exception("Unsafe Donrec custom table name for {$groupName}.");
+  }
+
+  $currentTableExists = CRM_Core_DAO::checkTableExists($currentTableName);
+  $expectedTableExists = CRM_Core_DAO::checkTableExists($expectedTableName);
+
+  if (!$currentTableExists && $expectedTableExists) {
+    CRM_Core_DAO::executeQuery(
+      'UPDATE `civicrm_custom_group` SET `table_name` = %1 WHERE `id` = %2',
+      [
+        1 => [$expectedTableName, 'String'],
+        2 => [(int) $customGroup['id'], 'Integer'],
+      ]
+    );
+    return;
+  }
+
+  if ($currentTableExists && !$expectedTableExists) {
+    CRM_Core_DAO::executeQuery("RENAME TABLE `{$currentTableName}` TO `{$expectedTableName}`");
+    CRM_Core_DAO::executeQuery(
+      'UPDATE `civicrm_custom_group` SET `table_name` = %1 WHERE `id` = %2',
+      [
+        1 => [$expectedTableName, 'String'],
+        2 => [(int) $customGroup['id'], 'Integer'],
+      ]
+    );
+    return;
+  }
+
+  if ($currentTableExists && $expectedTableExists) {
+    throw new CRM_Core_Exception(
+      "Both Donrec custom tables exist for {$groupName}: {$currentTableName} and {$expectedTableName}."
+    );
+  }
+
+  throw new CRM_Core_Exception("Missing Donrec custom table for {$groupName}: {$currentTableName}.");
 }
 
 /**


### PR DESCRIPTION
## What changed
This branch normalizes the two Donrec custom group table names during install and enable.

## Why
On some clean installs, CiviCRM derives translated custom table names, while Donrec expects deterministic technical table names.

## Impact
This keeps the normalization limited to install-time setup instead of adding a permanent runtime workaround.

## Validation
- php -l on donrec.php
- GitHub Actions on jonathandhn fork