### PR TITLE
Fix detection of custom field ID

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,20 @@
+# Do not search in parent directories.
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
 indent_size = 2
 indent_style = space
+trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 120
 tab_width = 2
 ij_continuation_indent_size = 2
 ij_visual_guides = 80,120
+
+[composer.{json,lock}]
+indent_size = 4
 
 [{*.php}]
 ij_php_align_assignments = false
@@ -238,3 +245,18 @@ ij_php_while_on_new_line = false
 [{*.neon,*.neon.dist,*neon.template}]
 indent_style = tab
 tab_width = 4
+
+[{*.yaml,*.yml}]
+ij_yaml_align_values_properties = do_not_align
+ij_yaml_autoinsert_sequence_marker = true
+ij_yaml_block_mapping_on_new_line = false
+ij_yaml_indent_sequence_value = true
+ij_yaml_keep_indents_on_empty_lines = false
+ij_yaml_keep_line_breaks = true
+ij_yaml_line_comment_add_space = false
+ij_yaml_line_comment_add_space_on_reformat = false
+ij_yaml_line_comment_at_first_column = false
+ij_yaml_sequence_on_new_line = false
+ij_yaml_space_before_colon = false
+ij_yaml_spaces_within_braces = true
+ij_yaml_spaces_within_brackets = true

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,5 +1,7 @@
 name: PHP_CodeSniffer
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -8,36 +10,42 @@ on:
       - phpcs.xml.dist
       - .github/workflows/phpcs.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpcs:
     runs-on: ubuntu-latest
     name: PHP_CodeSniffer
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 8.5
-        coverage: none
-        tools: cs2pr
-      env:
-        fail-fast: true
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: 8.5
+          coverage: none
+          tools: cs2pr
+        env:
+          fail-fast: true
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('tools/phpcs/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('tools/phpcs/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-    - name: Install dependencies
-      run: composer composer-phpcs -- update --no-progress --prefer-dist
+      - name: Install dependencies
+        run: composer composer-phpcs -- update --no-progress --prefer-dist
 
-    - name: Run PHP_CodeSniffer
-      run: composer phpcs -- -q --report=checkstyle | cs2pr
+      - name: Run PHP_CodeSniffer
+        run: composer phpcs -- -q --report=checkstyle | cs2pr

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,5 +1,7 @@
 name: PHPStan
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +14,7 @@ on:
       - '**.php'
       - composer.json
       - tools/phpstan/composer.json
+      - phpstan-baseline.neon
       - phpstan.ci.neon
       - phpstan.neon.dist
       - .github/workflows/phpstan.yml
@@ -23,64 +26,78 @@ concurrency:
 jobs:
   phpstan:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ['8.1', '8.5']
         prefer: ['prefer-stable', 'prefer-lowest']
+        experimental: [false]
+        include:
+          - php-versions: 8.6
+            prefer: prefer-source
+            experimental: true
     name: PHPStan with PHP ${{ matrix.php-versions }} ${{ matrix.prefer }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        coverage: none
-      env:
-        fail-fast: true
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+        env:
+          fail-fast: true
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
 
-    - name: Install dependencies
-      env:
-        COMPOSER_COMPILE: all
-      run: |
-        if [ "${{ matrix.prefer }}" = "prefer-lowest" ]; then
-          # Actually test with lowest possible versions.
-          export COMPOSER_NO_SECURITY_BLOCKING=1
-        fi
+      - name: Install dependencies
+        env:
+          COMPOSER_COMPILE: all
+          INPUTS_CIVICRM_VERSION: ${{ inputs.civicrm-version }}
+          MATRIX_PREFER: ${{ matrix.prefer }}
+        run: |
+          if [ "${MATRIX_PREFER}" = "prefer-lowest" ]; then
+            # Actually test with lowest possible versions.
+            export COMPOSER_NO_SECURITY_BLOCKING=1
+          fi
 
-        composer config --no-plugins allow-plugins.civicrm/composer-compile-plugin false
-        composer config --no-plugins allow-plugins.civicrm/composer-downloads-plugin true
-        composer config --no-plugins allow-plugins.composer/installers true
-        composer config --no-plugins allow-plugins.cweagans/composer-patches true
+          if [ "${{ matrix.experimental }}" == "true" ]; then
+            sed -E -i composer.json \
+              -e 's/"minimum-stability":[^,]*/"minimum-stability": "dev"/' \
+              -e 's/"prefer-stable":[^,]*/"prefer-stable": false/'
+          fi
 
-        composer config --json "extra.installer-paths.$(dirname $PWD)/{\$name}" '["type:civicrm-ext"]'
-        composer require --ignore-platform-reqs --no-progress composer/installers
+          composer config --no-plugins allow-plugins.civicrm/composer-compile-plugin false
+          composer config --no-plugins allow-plugins.civicrm/composer-downloads-plugin true
+          composer config --no-plugins allow-plugins.composer/installers true
+          composer config --no-plugins allow-plugins.cweagans/composer-patches true
 
-        if [ -n "${{ inputs.civicrm-version }}" ]; then
-          composer require --no-update "civicrm/civicrm-core:${{ inputs.civicrm-version }}" \
-            "civicrm/civicrm-packages:${{ inputs.civicrm-version }}"
-        fi
+          composer config --json "extra.installer-paths.$(dirname $PWD)/{\$name}" '["type:civicrm-ext"]'
+          composer require --ignore-platform-reqs --no-progress composer/installers
 
-        composer suggests --list | xargs -r composer require --no-update --${{ matrix.prefer }} --ignore-platform-reqs
+          if [ -n "${INPUTS_CIVICRM_VERSION}" ]; then
+            composer require --no-update "civicrm/civicrm-core:${INPUTS_CIVICRM_VERSION}" \
+              "civicrm/civicrm-packages:${INPUTS_CIVICRM_VERSION}"
+          fi
 
-        # Run with --no-scripts so ComposerHelper doesn't prevent installation
-        # of civicrm packages.
-        composer update --no-scripts --no-progress --${{ matrix.prefer }} --optimize-autoloader --ignore-platform-reqs
-        composer composer-phpunit -- update --no-progress --optimize-autoloader
-        composer composer-phpstan -- update --no-progress --optimize-autoloader
+          # Run with --no-scripts so ComposerHelper doesn't prevent installation
+          # of civicrm packages.
+          composer update --no-scripts --no-progress --${MATRIX_PREFER} --optimize-autoloader --ignore-platform-reqs
+          composer composer-phpunit -- update --no-progress --optimize-autoloader
+          composer composer-phpstan -- update --no-progress --optimize-autoloader
 
-    - name: Run PHPStan
-      run: composer phpstan -- analyse -c phpstan.ci.neon
+      - name: Run PHPStan
+        run: composer phpstan -- analyse -c phpstan.ci.neon

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,7 @@
 name: PHPUnit
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,109 +24,135 @@ concurrency:
 jobs:
   phpunit:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ['8.1', '8.5']
         prefer: ['prefer-stable', 'prefer-lowest']
+        experimental: [false]
+        include:
+          - php-versions: 8.6
+            prefer: prefer-source
+            experimental: true
     name: PHPUnit with PHP ${{ matrix.php-versions }} ${{ matrix.prefer }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        extensions: bcmath, curl, fileinfo, gd, intl, mbstring, mysqli, xml, zip
-        coverage: pcov
-      env:
-        fail-fast: true
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: bcmath, curl, fileinfo, gd, intl, mbstring, mysqli, xml, zip
+          coverage: pcov
+        env:
+          fail-fast: true
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
 
-    - name: Set up MySQL
-      run: |
-        # MySQL is installed by default.
-        # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#mysql
-        sudo systemctl start mysql.service
-        until sudo mysqladmin ping --silent; do sleep 1; done
-        sudo mysql -e 'CREATE DATABASE civicrm;' --user=root --password=root
-        sudo mysql -e 'CREATE USER "user"@"localhost" IDENTIFIED BY "password";' --user=root --password=root
-        sudo mysql -e 'GRANT ALL ON *.* TO "user"@"localhost";' --user=root --password=root
-        sudo mysql -e 'GRANT SUPER ON *.* TO "user"@"localhost";' --user=root --password=root
-        sudo mysql -e 'FLUSH PRIVILEGES;' --user=root --password=root
+      - name: Set up MySQL
+        run: |
+          # MySQL is installed by default.
+          # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#mysql
+          sudo systemctl start mysql.service
+          until sudo mysqladmin ping --silent; do sleep 1; done
+          sudo mysql -e 'CREATE DATABASE civicrm;' --user=root --password=root
+          sudo mysql -e 'CREATE USER "user"@"localhost" IDENTIFIED BY "password";' --user=root --password=root
+          sudo mysql -e 'GRANT ALL ON *.* TO "user"@"localhost";' --user=root --password=root
+          sudo mysql -e 'GRANT SUPER ON *.* TO "user"@"localhost";' --user=root --password=root
+          sudo mysql -e 'FLUSH PRIVILEGES;' --user=root --password=root
 
-    - name: Install dependencies
-      env:
-        COMPOSER_COMPILE: all
-      run: |
-        if [ "${{ matrix.prefer }}" = "prefer-lowest" ]; then
-          # Actually test with lowest possible versions.
-          export COMPOSER_NO_SECURITY_BLOCKING=1
-        fi
+      - name: Install dependencies
+        env:
+          COMPOSER_COMPILE: all
+          INPUTS_CIVICRM_VERSION: ${{ inputs.civicrm-version }}
+          MATRIX_PREFER: ${{ matrix.prefer }}
+        run: |
+          if [ "${MATRIX_PREFER}" = "prefer-lowest" ]; then
+            # Actually test with lowest possible versions.
+            export COMPOSER_NO_SECURITY_BLOCKING=1
+          fi
 
-        # Prevent this git error: The repository does not have the correct ownership and git refuses to use it
-        git config --global --add safe.directory "$PWD"
+          # Prevent this git error: The repository does not have the correct ownership and git refuses to use it
+          git config --global --add safe.directory "$PWD"
 
-        EXT_DIR=$PWD
-        EXT_COMPOSER_NAME=$(composer show --self --name-only)
-        composer composer-phpunit -- update --no-progress --optimize-autoloader
-        cd ..
-        git clone https://github.com/civicrm/civicrm-standalone.git
-        cd civicrm-standalone
+          EXT_DIR=$PWD
+          EXT_COMPOSER_NAME=$(composer show --self --name-only)
+          composer composer-phpunit -- update --no-progress --optimize-autoloader
+          cd ..
+          git clone https://github.com/civicrm/civicrm-standalone.git
+          cd civicrm-standalone
 
-        composer config --no-plugins allow-plugins.composer/installers true
-        composer config --no-plugins allow-plugins.cweagans/composer-patches true
-        composer config --json 'extra.installer-paths.ext/{$name}' '["type:civicrm-ext"]'
-        composer config repositories.test path $EXT_DIR
+          if [ "${{ matrix.experimental }}" == "true" ]; then
+            sed -E -i composer.json \
+              -e 's/"minimum-stability":[^,]*/"minimum-stability": "dev"/' \
+              -e 's/"prefer-stable":[^,]*/"prefer-stable": false/'
+            # Ignore upper bound of php requirement to test with development
+            # version of PHP, even if not allowed by some composer.json.
+            export COMPOSER_IGNORE_PLATFORM_REQ="php+"
+          fi
 
-        # Use civicrm-core and civicrm-packages defined in extension's composer.json.
-        composer remove --no-update civicrm/civicrm-core civicrm/civicrm-packages
-        composer require --no-progress composer/installers civicrm/cli-tools
-        if [ -n "${{ inputs.civicrm-version }}" ]; then
-          composer require --no-update "civicrm/civicrm-core:${{ inputs.civicrm-version }}" \
-            "civicrm/civicrm-packages:${{ inputs.civicrm-version }}"
-        fi
+          composer config --no-plugins allow-plugins.composer/installers true
+          composer config --no-plugins allow-plugins.cweagans/composer-patches true
+          composer config --json 'extra.installer-paths.ext/{$name}' '["type:civicrm-ext"]'
+          composer config repositories.test path $EXT_DIR
 
-        # --with-all-dependencies is required because downgrades from packages
-        # installed before might be necessary.
-        # \PEAR_ErrorStack::singleton() is static since pear/pear-core v1.10.16
-        # civicrm/composer-compile-plugin v0.22 is the minimum version
-        # compatible with symfony/console >=8.0 used in composer since 2.9.0.
-        composer require --with-all-dependencies --no-progress --${{ matrix.prefer }} \
-          --optimize-autoloader $EXT_COMPOSER_NAME 'pear/pear-core-minimal:>=1.10.16' \
-          'civicrm/composer-compile-plugin:>=0.22'
+          # Use civicrm-core and civicrm-packages defined in extension's composer.json.
+          composer remove --no-update civicrm/civicrm-core civicrm/civicrm-packages
+          composer require --no-progress composer/installers civicrm/cli-tools
+          if [ -n "${INPUTS_CIVICRM_VERSION}" ]; then
+            composer require --no-update "civicrm/civicrm-core:${INPUTS_CIVICRM_VERSION}" \
+              "civicrm/civicrm-packages:${INPUTS_CIVICRM_VERSION}"
+          fi
 
-    - name: Set up CiviCRM
-      env:
-        # Comma-separated list of CiviCRM components to enable, e.g.
-        # CiviEvent,CiviContribute. Components are mapped to extensions. If
-        # empty, all components are enabled. Enabling the dependent extensions
-        # should be actually triggered in the test class. Not enabling any
-        # component isn't possible.
-        CIVICRM_COMPONENTS: "CiviReport"
-        DATABASE_URL: mysql://user:password@127.0.0.1:3306/civicrm?new_link=true
-      run: |
-        cd ../civicrm-standalone
-        export PATH="$(realpath vendor/bin):$PATH"
-        cv core:install --db="$DATABASE_URL" --comp="$CIVICRM_COMPONENTS"
-        export CV_CONFIG="$HOME/.cv.json"
-        cv vars:fill --quiet
-        sed -i "s#\"TEST_DB_DSN\": \".*\"#\"TEST_DB_DSN\": \"$DATABASE_URL\"#g" "$CV_CONFIG"
+          # Install dev dependencies from extension's composer.json.
+          jq -r '.["require-dev"] | to_entries[] | "\"\(.key):\(.value)\""' "$EXT_DIR/composer.json" 2>/dev/null | xargs -r composer require --dev --no-update
 
-    - name: Run PHPUnit
-      run: |
-        export PATH="$(realpath ../civicrm-standalone/vendor/bin):$PATH"
-        export CV_CONFIG="$HOME/.cv.json"
-        cd ../civicrm-standalone/ext/$(basename "$PWD")
-        composer phpunit
+          # --with-all-dependencies is required because downgrades from packages
+          # installed before might be necessary.
+          # civicrm/composer-compile-plugin v0.22 is the minimum version
+          # compatible with symfony/console >=8.0 used in composer since 2.9.0.
+          composer require --with-all-dependencies --no-progress --${MATRIX_PREFER} \
+            --optimize-autoloader $EXT_COMPOSER_NAME 'civicrm/composer-compile-plugin:>=0.22'
+
+      - name: Set up CiviCRM
+        env:
+          # Comma-separated list of CiviCRM components to enable, e.g.
+          # CiviEvent,CiviContribute. Components are mapped to extensions. If
+          # empty, all components are enabled. Enabling the dependent extensions
+          # should be actually triggered in the test class. Not enabling any
+          # component isn't possible.
+          CIVICRM_COMPONENTS: "CiviReport"
+          DATABASE_URL: mysql://user:password@127.0.0.1:3306/civicrm?new_link=true
+        run: |
+          cd ../civicrm-standalone
+          export PATH="$(realpath vendor/bin):$PATH"
+          cv core:install --db="$DATABASE_URL" --comp="$CIVICRM_COMPONENTS"
+          export CV_CONFIG="$HOME/.cv.json"
+          cv vars:fill --quiet
+          sed -i "s#\"TEST_DB_DSN\": \".*\"#\"TEST_DB_DSN\": \"$DATABASE_URL\"#g" "$CV_CONFIG"
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run PHPUnit
+        run: |
+          export PATH="$(realpath ../civicrm-standalone/vendor/bin):$PATH"
+          export CV_CONFIG="$HOME/.cv.json"
+          cd ../civicrm-standalone/ext/$(basename "$PWD")
+          composer phpunit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*.*.*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -13,7 +17,9 @@ jobs:
     name: Create GitHub release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Package extension
         id: package-extension
@@ -26,21 +32,21 @@ jobs:
             exit 1
           fi
 
-          FILENAME="$EXT_LONG_NAME-${{ github.ref_name }}.zip"
-          git archive --prefix "$EXT_LONG_NAME/" --output="$FILENAME" --worktree-attributes "${{ github.ref_name }}"
+          FILENAME="$EXT_LONG_NAME-${GITHUB_REF_NAME}.zip"
+          git archive --prefix "$EXT_LONG_NAME/" --output="$FILENAME" --worktree-attributes "${GITHUB_REF_NAME}"
           echo "FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
 
       - name: Parse git tag
         id: version
         run: |
-          if echo ${{ github.ref_name }} | grep -Eq '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'; then
+          if echo ${GITHUB_REF_NAME} | grep -Eq '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'; then
             echo "PRERELEASE=false" >> "$GITHUB_OUTPUT"
           else
             echo "PRERELEASE=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifactErrorsFailBuild: true
           draft: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,11 +8,15 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-stale: 90
           days-before-close: 30

--- a/CRM/Donrec/CustomData.php
+++ b/CRM/Donrec/CustomData.php
@@ -19,7 +19,7 @@
 declare(strict_types = 1);
 
 class CRM_Donrec_CustomData {
-  public const CUSTOM_DATA_HELPER_VERSION   = '0.13.0';
+  public const CUSTOM_DATA_HELPER_VERSION   = '0.13.1';
   public const CUSTOM_DATA_HELPER_LOG_LEVEL = 0;
   public const CUSTOM_DATA_HELPER_LOG_DEBUG = 1;
   public const CUSTOM_DATA_HELPER_LOG_INFO  = 3;
@@ -80,6 +80,8 @@ class CRM_Donrec_CustomData {
     if (!is_array($data['_entities'])) {
       throw new InvalidArgumentException('syncOptionGroup::syncOptionGroup: Invalid specs');
     }
+
+    assert(is_string($data['entity']));
 
     /** @var array<string, mixed> $entity_data */
     foreach ($data['_entities'] as $entity_data) {
@@ -811,6 +813,7 @@ class CRM_Donrec_CustomData {
     // look for all group names in all variables
     foreach ($group_names as $group_name) {
       foreach (array_keys($params) as $key) {
+        /** @var string $new_key */
         $new_key = preg_replace("#^{$group_name}_#", "{$group_name}.", $key);
         if ($new_key !== $key) {
           $params[$new_key] = $params[$key];

--- a/CRM/Donrec/Form/Task/Rebook.php
+++ b/CRM/Donrec/Form/Task/Rebook.php
@@ -101,7 +101,6 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
           'error'
         );
         CRM_Utils_System::redirect($redirect_url);
-        return NULL;
       }
     }
 
@@ -113,7 +112,6 @@ class CRM_Donrec_Form_Task_Rebook extends CRM_Core_Form {
         'error'
       );
       CRM_Utils_System::redirect($redirect_url);
-      return NULL;
     }
     else {
       // @phpstan-ignore return.type

--- a/CRM/Donrec/Lang/Pl/Kwota.php
+++ b/CRM/Donrec/Lang/Pl/Kwota.php
@@ -215,20 +215,18 @@ class Kwota {
   }
 
   /**
-   * @param $licz
-   * @param $i
    * @param array|null $table
    *
    * @return string
    */
-  protected function _mnoznikSlownie($licz, $i, $table = NULL) {
-    $table = $table ? $table : $this->table[$i];
-    if ($licz == 1) {
+  protected function _mnoznikSlownie(string $licz, ?int $i, ?array $table = NULL) {
+    $table ??= $this->table[$i];
+    if ($licz === '1') {
       return $table[0];
     }
     $licz = str_pad($licz, 3, '0', STR_PAD_LEFT);
-    $last   = $licz[strlen($licz) - 1];
-    $second = (isset($licz[1]) && $licz[1] < 2 && $licz[1] > 0) ? TRUE : FALSE;
+    $last = (int) $licz[strlen($licz) - 1];
+    $second = isset($licz[1]) && (int) $licz[1] < 2 && (int) $licz[1] > 0;
     if (($second) || ($last < 2 || $last > 4)) {
       return $table[2];
     }
@@ -249,7 +247,7 @@ class Kwota {
     }
     if (strlen($liczba) > 2) {
       $r[] = $this->setki[$liczba[0]];
-      $liczba = ($liczba - $liczba[0] * 100) . '';
+      $liczba = (string) ((int) $liczba - (int) $liczba[0] * 100);
     }
     if ((int) $liczba < 20) {
       $r[] = $this->jednosciNascie[$liczba];

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -682,8 +682,9 @@ class CRM_Donrec_Logic_Profile {
         ->addWhere('domain_id', '=', 'current_domain')
         ->addWhere('is_active', '=', TRUE)
         ->addWhere('is_default', '=', TRUE)
+        ->setLimit(1)
         ->execute()
-        ->first()['id'];
+        ->single()['id'];
     }
 
     return (int) OptionValue::get(FALSE)
@@ -691,8 +692,9 @@ class CRM_Donrec_Logic_Profile {
       ->addWhere('option_group_id:name', '=', 'from_email_address')
       ->addWhere('is_active', '=', TRUE)
       ->addWhere('is_default', '=', TRUE)
+      ->setLimit(1)
       ->execute()
-      ->first()['value'];
+      ->single()['value'];
   }
 
   /**

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -683,7 +683,7 @@ class CRM_Donrec_Logic_Profile {
         ->addWhere('is_active', '=', TRUE)
         ->addWhere('is_default', '=', TRUE)
         ->execute()
-        ->single()['id'];
+        ->first()['id'];
     }
 
     return (int) OptionValue::get(FALSE)
@@ -692,7 +692,7 @@ class CRM_Donrec_Logic_Profile {
       ->addWhere('is_active', '=', TRUE)
       ->addWhere('is_default', '=', TRUE)
       ->execute()
-      ->single()['value'];
+      ->first()['value'];
   }
 
   /**

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -100,12 +100,12 @@ class CRM_Donrec_Logic_Profile {
   }
 
   /**
-   * @param int $profile_id
+   * @param int|numeric-string|null $profile_id
    *
    * @return \CRM_Donrec_Logic_Profile
    */
-  public static function getProfile($profile_id) {
-    return new self($profile_id);
+  public static function getProfile(int|string|null $profile_id): self {
+    return new self(NULL === $profile_id ? NULL : (int) $profile_id);
   }
 
   /**

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -76,12 +76,10 @@ class CRM_Donrec_Logic_Profile {
 
   /**
    * load setting entity with given ID
-   *
-   * @param int $profile_id
    */
-  public function __construct($profile_id = NULL) {
+  public function __construct(?int $profile_id = NULL) {
     $all_profiles = self::getAllData();
-    if (isset($all_profiles[$profile_id])) {
+    if (NULL !== $profile_id && isset($all_profiles[$profile_id])) {
       $profile_data = $all_profiles[$profile_id];
     }
     else {
@@ -683,7 +681,10 @@ class CRM_Donrec_Logic_Profile {
     else {
       $condition = NULL;
     }
-    return key(CRM_Core_OptionGroup::values('from_email_address', FALSE, FALSE, FALSE, $condition));
+
+    /** @var non-empty-array<string, string> $fromEmailAddresses */
+    $fromEmailAddresses = CRM_Core_OptionGroup::values('from_email_address', FALSE, FALSE, FALSE, $condition);
+    return key($fromEmailAddresses);
   }
 
   /**

--- a/CRM/Donrec/Logic/Profile.php
+++ b/CRM/Donrec/Logic/Profile.php
@@ -10,6 +10,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\OptionValue;
+use Civi\Api4\SiteEmailAddress;
 use CRM_Donrec_ExtensionUtil as E;
 
 /**
@@ -100,12 +102,12 @@ class CRM_Donrec_Logic_Profile {
   }
 
   /**
-   * @param int|numeric-string|null $profile_id
+   * @param int|numeric-string $profile_id
    *
    * @return \CRM_Donrec_Logic_Profile
    */
-  public static function getProfile(int|string|null $profile_id): self {
-    return new self(NULL === $profile_id ? NULL : (int) $profile_id);
+  public static function getProfile(int|string $profile_id): self {
+    return new self((int) $profile_id);
   }
 
   /**
@@ -667,24 +669,30 @@ class CRM_Donrec_Logic_Profile {
   }
 
   /**
-   * Returns "From" e-mail addresses configured within CiviCRM.
+   * @return int
+   *   The ID of the default "From" email address configured within CiviCRM.
    *
-   * @param bool $default
-   *   Whether to return only default addresses.
-   *
-   * @return string
+   * @throws \CRM_Core_Exception
    */
-  public static function getFromEmailAddresses($default = FALSE) {
-    if ($default) {
-      $condition = ' AND is_default = 1';
-    }
-    else {
-      $condition = NULL;
+  public static function getDefaultSiteEmailAddressId(): int {
+    // TODO: Remove check when minimum core version requirement is >= 6.0.0.
+    if (class_exists(SiteEmailAddress::class)) {
+      return SiteEmailAddress::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('domain_id', '=', 'current_domain')
+        ->addWhere('is_active', '=', TRUE)
+        ->addWhere('is_default', '=', TRUE)
+        ->execute()
+        ->single()['id'];
     }
 
-    /** @var non-empty-array<string, string> $fromEmailAddresses */
-    $fromEmailAddresses = CRM_Core_OptionGroup::values('from_email_address', FALSE, FALSE, FALSE, $condition);
-    return key($fromEmailAddresses);
+    return (int) OptionValue::get(FALSE)
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'from_email_address')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('is_default', '=', TRUE)
+      ->execute()
+      ->single()['value'];
   }
 
   /**
@@ -741,7 +749,7 @@ class CRM_Donrec_Logic_Profile {
         'postal_address'             => ['0'],
         'legal_address_fallback'     => ['0'],
         'postal_address_fallback'    => ['0'],
-        'from_email'                 => CRM_Donrec_Logic_Profile::getFromEmailAddresses(TRUE),
+        'from_email'                 => CRM_Donrec_Logic_Profile::getDefaultSiteEmailAddressId(),
         // TODO: Set correct defaults for formerly global settings here.
         'email_template'             => NULL,
         'bcc_email'                  => NULL,

--- a/CRM/Donrec/Logic/Receipt.php
+++ b/CRM/Donrec/Logic/Receipt.php
@@ -233,8 +233,7 @@ class CRM_Donrec_Logic_Receipt extends CRM_Donrec_Logic_ReceiptTokens {
   public function getCopies() {
     $receipt_id = $this->Id;
     $receipt_fields = self::$_custom_fields;
-    CRM_Donrec_Logic_ReceiptItem::getCustomFields();
-    $item_fields = CRM_Donrec_Logic_ReceiptItem::$_custom_fields;
+    $item_fields = CRM_Donrec_Logic_ReceiptItem::getCustomFields();
     $receipt_table_name = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt');
     $item_table_name = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
     $query = "
@@ -482,11 +481,10 @@ class CRM_Donrec_Logic_Receipt extends CRM_Donrec_Logic_ReceiptTokens {
   // phpcs:enable
     $values = [];
 
-    CRM_Donrec_Logic_ReceiptItem::getCustomFields();
     $expected_fields = CRM_Donrec_Logic_ReceiptTokens::$STORED_TOKENS;
     $receipt_id = $this->Id;
     $receipt_fields = self::$_custom_fields;
-    $item_fields = CRM_Donrec_Logic_ReceiptItem::$_custom_fields;
+    $item_fields = CRM_Donrec_Logic_ReceiptItem::getCustomFields();
     $receipt_table_name = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt');
     $item_table_name = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
 
@@ -656,7 +654,6 @@ class CRM_Donrec_Logic_Receipt extends CRM_Donrec_Logic_ReceiptTokens {
    * get the profile object that was used to create this receipt
    */
   public function getProfile() {
-    CRM_Donrec_Logic_ReceiptItem::getCustomFields();
     $receipt_table_name = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt');
     $profile_column_name = CRM_Donrec_DataStructure::getCustomFields('zwb_donation_receipt')['profile_id'];
     $profile_id = (int) CRM_Core_DAO::singleValueQuery(

--- a/CRM/Donrec/Logic/ReceiptItem.php
+++ b/CRM/Donrec/Logic/ReceiptItem.php
@@ -10,6 +10,8 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\CustomField;
+
 /**
  * This class represents a single donation receipt item
  */
@@ -19,7 +21,7 @@ class CRM_Donrec_Logic_ReceiptItem {
    * i.e. self::$_custom_field['total_amount'] == 10
    */
   // TODO: set private, but add getters
-  public static ?array $_custom_fields = NULL;
+  private static ?array $_custom_fields = NULL;
   public static ?int $_custom_group_id = NULL;
   public static array $_checksum_keys = [
     'contribution_id',
@@ -45,8 +47,7 @@ class CRM_Donrec_Logic_ReceiptItem {
    * @throws \CRM_Core_Exception
    */
   public static function create($params) {
-    self::getCustomFields();
-    $fields = self::$_custom_fields ?? [];
+    $fields = self::getCustomFields();
     $table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
     $params['contribution_hash'] = self::calculateChecksum($params);
 
@@ -88,22 +89,22 @@ class CRM_Donrec_Logic_ReceiptItem {
    */
   public static function createCopyAll($donation_receipt_id, $donation_receipt_copy_id) {
     // TODO: make a generic version of this, using the fields defined in CRM_Donrec_DataStructure
-    self::getCustomFields();
+    $custom_fields = self::getCustomFields();
     $receipt_item_table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
     // phpcs:disable Generic.Files.LineLength.TooLong
     $sha1_string = "SHA1(CONCAT(`entity_id`, 'COPY', `%s`, $donation_receipt_copy_id, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`, `%s`))";
     // phpcs:enable
     $sha1_string = sprintf($sha1_string,
-                          self::$_custom_fields['type'],
-                          self::$_custom_fields['issued_in'],
-                          self::$_custom_fields['receipt_id'],
-                          self::$_custom_fields['issued_by'],
-                          self::$_custom_fields['total_amount'],
-                          self::$_custom_fields['non_deductible_amount'],
-                          self::$_custom_fields['financial_type_id'],
-                          self::$_custom_fields['currency'],
-                          self::$_custom_fields['issued_on'],
-                          self::$_custom_fields['receive_date'],
+                          $custom_fields['type'],
+                          $custom_fields['issued_in'],
+                          $custom_fields['receipt_id'],
+                          $custom_fields['issued_by'],
+                          $custom_fields['total_amount'],
+                          $custom_fields['non_deductible_amount'],
+                          $custom_fields['financial_type_id'],
+                          $custom_fields['currency'],
+                          $custom_fields['issued_on'],
+                          $custom_fields['receive_date'],
                           self::$_custom_group_id);
 
     $query = "INSERT INTO `$receipt_item_table`
@@ -139,35 +140,35 @@ class CRM_Donrec_Logic_ReceiptItem {
     WHERE `%s` = %d AND `%s` = 'ORIGINAL';";
     $query = sprintf($query,
       // for spec part
-      self::$_custom_fields['status'],
-      self::$_custom_fields['type'],
-      self::$_custom_fields['issued_in'],
-      self::$_custom_fields['receipt_id'],
-      self::$_custom_fields['issued_on'],
-      self::$_custom_fields['issued_by'],
-      self::$_custom_fields['total_amount'],
-      self::$_custom_fields['non_deductible_amount'],
-      self::$_custom_fields['currency'],
-      self::$_custom_fields['financial_type_id'],
-      self::$_custom_fields['receive_date'],
-      self::$_custom_fields['contribution_hash'],
+      $custom_fields['status'],
+      $custom_fields['type'],
+      $custom_fields['issued_in'],
+      $custom_fields['receipt_id'],
+      $custom_fields['issued_on'],
+      $custom_fields['issued_by'],
+      $custom_fields['total_amount'],
+      $custom_fields['non_deductible_amount'],
+      $custom_fields['currency'],
+      $custom_fields['financial_type_id'],
+      $custom_fields['receive_date'],
+      $custom_fields['contribution_hash'],
       // for VALUES part
-      self::$_custom_fields['status'],
-      self::$_custom_fields['type'],
-      self::$_custom_fields['issued_in'],
-      self::$_custom_fields['receipt_id'],
-      self::$_custom_fields['issued_on'],
-      self::$_custom_fields['issued_by'],
-      self::$_custom_fields['total_amount'],
-      self::$_custom_fields['non_deductible_amount'],
-      self::$_custom_fields['currency'],
-      self::$_custom_fields['financial_type_id'],
-      self::$_custom_fields['receive_date'],
+      $custom_fields['status'],
+      $custom_fields['type'],
+      $custom_fields['issued_in'],
+      $custom_fields['receipt_id'],
+      $custom_fields['issued_on'],
+      $custom_fields['issued_by'],
+      $custom_fields['total_amount'],
+      $custom_fields['non_deductible_amount'],
+      $custom_fields['currency'],
+      $custom_fields['financial_type_id'],
+      $custom_fields['receive_date'],
       $sha1_string,
-      self::$_custom_fields['contribution_hash'],
-      self::$_custom_fields['issued_in'],
+      $custom_fields['contribution_hash'],
+      $custom_fields['issued_in'],
       $donation_receipt_id,
-      self::$_custom_fields['status']
+      $custom_fields['status']
       );
     $result = CRM_Core_DAO::executeQuery($query);
   }
@@ -178,10 +179,10 @@ class CRM_Donrec_Logic_ReceiptItem {
    * @param string|null $status filter by status (deletes all including copies if not specified)
    */
   public static function deleteAll($donation_receipt_id, $status = NULL) {
-    self::getCustomFields();
+    $custom_fields = self::getCustomFields();
     $receipt_item_table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
     if (!empty($status)) {
-      $statusString = sprintf(" AND `%s` = '%s'", self::$_custom_fields['status'], $status);
+      $statusString = sprintf(" AND `%s` = '%s'", $custom_fields['status'], $status);
     }
     else {
       $statusString = '';
@@ -189,7 +190,7 @@ class CRM_Donrec_Logic_ReceiptItem {
 
     $query = "DELETE FROM `$receipt_item_table` WHERE `%s` = %d%s;";
     $query = sprintf($query,
-                    self::$_custom_fields['issued_in'],
+                    $custom_fields['issued_in'],
                     $donation_receipt_id,
                     $statusString);
     $result = CRM_Core_DAO::executeQuery($query);
@@ -201,12 +202,12 @@ class CRM_Donrec_Logic_ReceiptItem {
    * @param string $status
    */
   public static function setStatusAll($donation_receipt_id, $status = 'WITHDRAWN') {
-    self::getCustomFields();
+    $custom_fields = self::getCustomFields();
     $receipt_item_table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
     $query = "UPDATE `$receipt_item_table` SET `%s` = %%1 WHERE `%s` = %d;";
     $query = sprintf($query,
-                    self::$_custom_fields['status'],
-                    self::$_custom_fields['issued_in'],
+                    $custom_fields['status'],
+                    $custom_fields['issued_in'],
                     $donation_receipt_id
                     );
     $params = [1 => [$status, 'String']];
@@ -214,41 +215,19 @@ class CRM_Donrec_Logic_ReceiptItem {
   }
 
   /**
-   * Updates the class attribute to contain all custom fields of the
-   * donation receipt database table.
+   * @return array<string, string>
+   *   Mapping of field name in CustomGroup zwb_donation_receipt_item to column
+   *   name.
    *
-   * @return array|null
+   * @throws \CRM_Core_Exception
    */
-  public static function getCustomFields() {
-    if (self::$_custom_fields === NULL) {
-      // get the ids of all relevant custom fields
-      $params = [
-        'name'       => 'zwb_donation_receipt_item',
-      ];
-      $custom_group = civicrm_api3('CustomGroup', 'getsingle', $params);
-      if (isset($custom_group['is_error'])) {
-        Civi::log()->debug(sprintf('de.systopia.donrec: getCustomFields: error: %s', $custom_group['error_message']));
-        return NULL;
-      }
-
-      self::$_custom_group_id = (int) $custom_group['id'];
-
-      $params = [
-        'option.limit'    => 999,
-        'custom_group_id' => $custom_group['id'],
-      ];
-      $custom_fields = civicrm_api3('CustomField', 'get', $params);
-      if ($custom_fields['is_error'] != 0) {
-        Civi::log()->debug(sprintf('de.systopia.donrec: getCustomFields: error: %s', $custom_fields['error_message']));
-        return NULL;
-      }
-
-      self::$_custom_fields = [];
-      foreach ($custom_fields['values'] as $field) {
-        self::$_custom_fields[$field['name']] = $field['column_name'];
-      }
-    }
-    return self::$_custom_fields;
+  public static function getCustomFields(): array {
+    return self::$_custom_fields ??= CustomField::get(FALSE)
+      ->addSelect('name', 'column_name')
+      ->addWhere('custom_group_id.name', '=', 'zwb_donation_receipt_item')
+      ->execute()
+      ->indexBy('name')
+      ->column('column_name');
   }
 
   /**
@@ -266,9 +245,8 @@ class CRM_Donrec_Logic_ReceiptItem {
       return FALSE;
     }
 
-    self::getCustomFields();
     $receipt_item_table = CRM_Donrec_DataStructure::getTableName('zwb_donation_receipt_item');
-    $status_field = self::$_custom_fields['status'];
+    $status_field = self::getCustomFields()['status'];
 
     $query = "
       SELECT `id`

--- a/CRM/Utils/DonrecHelper.php
+++ b/CRM/Utils/DonrecHelper.php
@@ -10,6 +10,7 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\Contribution;
 use CRM_Donrec_ExtensionUtil as E;
 
 /**
@@ -111,65 +112,27 @@ class CRM_Utils_DonrecHelper {
   }
 
   /**
-   * extracts the field ID from the field set provided in the format:
-   * <field_name> => <column_name>
-   *
-   * @param array $fields
-   *
    * @param string $field_name
+   *   APIv4 field name of a custom Contribution field. If the group name is
+   *   omitted, "zwb_donation_receipt_item" will be used.
    *
-   * @return int
-   *   field_id  or 0 if not found
+   * @return int|null
+   *   Custom field ID or NULL if not found.
    */
-  public static function getFieldID($fields, $field_name) {
-    if (!empty($fields[$field_name])) {
-      // TODO: more efficient way?
-      $inv_column = strrev($fields[$field_name]);
-      $inv_id = substr($inv_column, 0, strpos($inv_column, '_'));
-      return (int) strrev($inv_id);
-    }
-    else {
-      return 0;
-    }
-  }
+  public static function getCustomFieldId(string $field_name): ?int {
+    static $customFieldIds;
+    $customFieldIds ??= Contribution::getFields(FALSE)
+      ->addSelect('name', 'custom_field_id')
+      ->addWhere('custom_field_id', 'IS NOT NULL')
+      ->execute()
+      ->indexBy('name')
+      ->column('custom_field_id');
 
-  /**
-   * removes a field from a form - if it exists
-   *
-   * @param \CRM_Core_Form $form
-   *
-   * @param array $fields
-   *
-   * @param string $field_name
-   */
-  public static function removeFromForm(&$form, $fields, $field_name) {
-    $field_id = self::getFieldID($fields, $field_name);
-    if ($field_id) {
-      if ($form->elementExists("custom_{$field_id}")) {
-        $form->removeElement("custom_{$field_id}");
-      }
+    if (!str_contains($field_name, '.')) {
+      $field_name = 'zwb_donation_receipt_item.' . $field_name;
     }
-  }
 
-  /**
-   * updates a date field's labels - if it exists
-   *
-   * @param $form
-   * @param $fields
-   * @param $field_name
-   * @param $from_label
-   * @param $to_label
-   */
-  public static function relabelDateField(&$form, $fields, $field_name, $from_label, $to_label) {
-    $field_id = self::getFieldID($fields, $field_name);
-    if ($field_id) {
-      if ($form->elementExists("custom_{$field_id}_from")) {
-        $form->getElement("custom_{$field_id}_from")->setLabel($from_label);
-      }
-      if ($form->elementExists("custom_{$field_id}_to")) {
-        $form->getElement("custom_{$field_id}_to")->setLabel($to_label);
-      }
-    }
+    return $customFieldIds['zwb_donation_receipt_item.' . $field_name] ?? NULL;
   }
 
   /**

--- a/ComposerHelper.php
+++ b/ComposerHelper.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Donrec;
 
 use Composer\Package\Link;
-use Composer\Repository\RepositoryManager;
 use Composer\Script\Event;
 
 final class ComposerHelper {
@@ -15,15 +14,17 @@ final class ComposerHelper {
   public static function preUpdate(Event $event): void {
     $repositoryManager = $event->getComposer()->getRepositoryManager();
     $package = $event->getComposer()->getPackage();
+
+    $filterCallback = fn (Link $require, string $name) =>
+      'civicrm/civicrm-core' !== $name &&
+      'civicrm/civicrm-packages' !== $name &&
+      'civicrm-ext' !== $repositoryManager->findPackage($name, $require->getConstraint())?->getType();
+
     $package->setRequires(
-      array_filter(
-        $package->getRequires(),
-        fn (Link $require, string $name) =>
-          'civicrm/civicrm-core' !== $name &&
-          'civicrm/civicrm-packages' !== $name &&
-          'civicrm-ext' !== $repositoryManager->findPackage($name, $require->getConstraint())?->getType(),
-        ARRAY_FILTER_USE_BOTH
-      )
+      array_filter($package->getRequires(), $filterCallback, ARRAY_FILTER_USE_BOTH)
+    );
+    $package->setDevRequires(
+      array_filter($package->getDevRequires(), $filterCallback, ARRAY_FILTER_USE_BOTH)
     );
   }
 

--- a/composer.json
+++ b/composer.json
@@ -42,15 +42,7 @@
         "composer-phpunit": [
             "@composer --working-dir=tools/phpunit"
         ],
-        "composer-rector": [
-            "@composer --working-dir=tools/rector"
-        ],
-        "composer-cs-fixer": [
-            "@composer --working-dir=tools/php-cs-fixer"
-        ],
         "composer-tools": [
-            "@composer-cs-fixer",
-            "@composer-rector",
             "@composer-phpcs",
             "@composer-phpstan",
             "@composer-phpunit"
@@ -67,37 +59,27 @@
         "phpunit": [
             "@php tools/phpunit/vendor/bin/simple-phpunit --coverage-text"
         ],
-        "rector": [
-            "@php tools/rector/vendor/bin/rector process"
-        ],
-        "rector:test": [
-            "@php tools/rector/vendor/bin/rector process --dry-run"
-        ],
-        "cs-fixer": [
-            "@php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=php-cs-fixer.php"
-        ],
-        "cs-fixer:test": [
-            "@php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff --config=php-cs-fixer.php"
-        ],
-        "fix": [
-            "@rector",
-            "@cs-fixer",
-            "@phpcbf"
-        ],
         "test": [
-            "@rector:test",
-            "@cs-fixer:test",
             "@phpcs",
             "@phpstan",
             "@phpunit"
         ]
     },
     "conflict": {
-        "pear/mail_mime": "<1.10.2"
+        "pear/mail_mime": "<1.10.2",
+        "pear/pear-core-minimal": "<1.10.16",
+        "symfony/polyfill-php82": "<1.28"
     },
+    "_comment": [
+      "PEAR_ErrorStack::singleton() overridden in CRM_Core_Error is static since pear/pear-core v1.10.16",
+      "symfony/polyfill-php82 >=1.28 is required for the ini_parse_quantity() polyfill that CiviCRM core calls during bootstrap; civicrm-core only requires ^1.0, so prefer-lowest would otherwise pick v1.27.0 (without the polyfill) and break PHPUnit on PHP 8.1"
+    ],
     "extra": {
         "branch-alias": {
             "dev-master": "2.5.x-dev"
         }
+    },
+    "require-dev": {
+        "systopia/de.systopia.civioffice": "^1 || ^2"
     }
 }

--- a/donrec.php
+++ b/donrec.php
@@ -358,7 +358,7 @@ function donrec_civicrm_pre(string $op, string $objectName, $id, array &$params)
         // Validate the contribution values to be set.
         CRM_Donrec_Logic_Settings::validateContribution($id, (array) $result, $params, TRUE);
       }
-      elseif ($op == 'delete') {
+      else {
         $message = sprintf(
           E::ts('This contribution [%d] must not be deleted because it has a receipt or is going to be receipted!'),
           $id
@@ -436,24 +436,23 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
 // phpcs:enable
   if ($formName == 'CRM_Contribute_Form_Search') {
     /** @var CRM_Contribute_Form_Search $form */
-    $item_fields = CRM_Donrec_Logic_ReceiptItem::getCustomFields() ?? [];
 
     // remove unwanted fields
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'financial_type_id');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'total_amount');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'non_deductible_amount');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'currency');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'contribution_hash');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_on');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'receive_date');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_in');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('financial_type_id');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('total_amount');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('non_deductible_amount');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('currency');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('contribution_hash');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('issued_on');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('receive_date');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('issued_in');
     $form->assign('field_ids_to_remove', implode(',', $field_ids_to_remove));
     CRM_Core_Region::instance('page-body')->add([
       'template' => 'CRM/Donrec/Form/Search/RemoveFields.snippet.tpl',
     ]);
 
     // override the standard fields
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'status');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('status');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
         E::ts('Status'),
@@ -466,7 +465,7 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
           'withdrawn_copy'  => E::ts('withdrawn_copy'),
         ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'type');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('type');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
         E::ts('Type'),
@@ -477,11 +476,11 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
           'bulk'    => E::ts('bulk receipt'),
         ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_in');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('issued_in');
     if ($status_id) {
       $form->add('text', "custom_{$status_id}", E::ts('Receipt ID'));
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_by');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('issued_by');
     if ($status_id) {
       $form->add('text', "custom_{$status_id}", E::ts('Issued by contact'));
     }
@@ -491,42 +490,41 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
     /** @var CRM_Contact_Form_Search_Advanced $form */
     // remove unwanted fields
     $item_fields = CRM_Donrec_Logic_Receipt::getCustomFields() ?? [];
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_on');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'original_file');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'contact_type');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'gender');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'prefix');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'display_name');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'postal_greeting_display');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'email_greeting_display');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'addressee_display');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'street_address');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'supplemental_address_1');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'supplemental_address_2');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'supplemental_address_3');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'postal_code');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'city');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'country');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_addressee_display');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_street_address');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_supplemental_address_1');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_supplemental_address_2');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_supplemental_address_3');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_postal_code');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_city');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'shipping_country');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'date_from');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'date_to');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('issued_on');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('original_file');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('contact_type');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('gender');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('prefix');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('display_name');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('postal_greeting_display');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('email_greeting_display');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('addressee_display');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('street_address');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('supplemental_address_1');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('supplemental_address_2');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('supplemental_address_3');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('postal_code');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('city');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('country');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_addressee_display');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_street_address');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_supplemental_address_1');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_supplemental_address_2');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_supplemental_address_3');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_postal_code');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_city');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('shipping_country');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('date_from');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('date_to');
 
     // remove unwanted fields from receipt items (in contribution tab)
-    $item_fields_receipt = CRM_Donrec_Logic_ReceiptItem::getCustomFields() ?? [];
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'financial_type_id');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'total_amount');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'non_deductible_amount');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'currency');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'contribution_hash');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'issued_on');
-    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'receive_date');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('financial_type_id');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('total_amount');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('non_deductible_amount');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('currency');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('contribution_hash');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('issued_on');
+    $field_ids_to_remove[] = CRM_Utils_DonrecHelper::getCustomFieldId('receive_date');
 
     $form->assign('field_ids_to_remove', implode(',', $field_ids_to_remove));
     CRM_Core_Region::instance('page-body')->add([
@@ -534,7 +532,7 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
     ]);
 
     // override the standard fields
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'status');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('status');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
       E::ts('Status'),
@@ -547,7 +545,7 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
         'withdrawn_copy'  => E::ts('withdrawn_copy'),
       ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'type');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('type');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
       E::ts('Type'),
@@ -558,13 +556,13 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
         'bulk'    => E::ts('bulk receipt'),
       ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields, 'issued_by');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('issued_by');
     if ($status_id) {
       $form->add('text', "custom_{$status_id}", E::ts('Issued by contact'));
     }
 
     // override the receipt_item standard fields
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'status');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('status');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
       E::ts('Status'),
@@ -577,7 +575,7 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
         'withdrawn_copy'  => E::ts('withdrawn_copy'),
       ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'type');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('type');
     if ($status_id) {
       $form->add('select', "custom_{$status_id}",
       E::ts('Type'),
@@ -588,11 +586,11 @@ function donrec_civicrm_buildForm(string $formName, object $form): void {
         'bulk'    => E::ts('bulk receipt'),
       ]);
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'issued_in');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('issued_in');
     if ($status_id) {
       $form->add('text', "custom_{$status_id}", E::ts('Receipt ID'));
     }
-    $status_id = CRM_Utils_DonrecHelper::getFieldID($item_fields_receipt, 'issued_by');
+    $status_id = CRM_Utils_DonrecHelper::getCustomFieldId('issued_by');
     if ($status_id) {
       $form->add('text', "custom_{$status_id}", E::ts('Issued by contact'));
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,7 +67,7 @@ parameters:
 			path: CRM/Admin/Form/DonrecProfile.php
 
 		-
-			message: '#^Parameter \#1 \$profile_id of static method CRM_Donrec_Logic_Profile\:\:getProfile\(\) expects int, mixed given\.$#'
+			message: '#^Parameter \#1 \$profile_id of static method CRM_Donrec_Logic_Profile\:\:getProfile\(\) expects int\|numeric\-string, mixed given\.$#'
 			identifier: argument.type
 			count: 5
 			path: CRM/Admin/Form/DonrecProfile.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,30 +121,6 @@ parameters:
 			path: CRM/Admin/Page/DonrecProfiles.php
 
 		-
-			message: '#^Parameter \#1 \$entity_type of method CRM_Donrec_CustomData\:\:createEntity\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Donrec/CustomData.php
-
-		-
-			message: '#^Parameter \#1 \$entity_type of method CRM_Donrec_CustomData\:\:identifyEntity\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Donrec/CustomData.php
-
-		-
-			message: '#^Parameter \#1 \$entity_type of method CRM_Donrec_CustomData\:\:updateEntity\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Donrec/CustomData.php
-
-		-
-			message: '#^Part \$data\[''entity''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: CRM/Donrec/CustomData.php
-
-		-
 			message: '#^Cannot access offset ''count'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -553,6 +529,12 @@ parameters:
 			path: CRM/Donrec/Exporters/GroupedPDF.php
 
 		-
+			message: '#^Equal\: Insane comparison between 2 and 2\.$#'
+			identifier: voku.Equal
+			count: 1
+			path: CRM/Donrec/Exporters/GroupedPDF.php
+
+		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
@@ -622,6 +604,12 @@ parameters:
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 5
+			path: CRM/Donrec/Exporters/MergedPDF.php
+
+		-
+			message: '#^Equal\: Insane comparison between 2 and 2\.$#'
+			identifier: voku.Equal
+			count: 1
 			path: CRM/Donrec/Exporters/MergedPDF.php
 
 		-
@@ -1261,12 +1249,6 @@ parameters:
 			path: CRM/Donrec/Lang.php
 
 		-
-			message: '#^Method CRM_Donrec_Lang\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang.php
-
-		-
 			message: '#^Only booleans are allowed in &&, CRM_Donrec_Logic_Profile\|null given on the right side\.$#'
 			identifier: booleanAnd.rightNotBoolean
 			count: 1
@@ -1312,12 +1294,6 @@ parameters:
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
 			count: 2
-			path: CRM/Donrec/Lang/De/De.php
-
-		-
-			message: '#^Method CRM_Donrec_Lang_De_De\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
 			path: CRM/Donrec/Lang/De/De.php
 
 		-
@@ -1369,12 +1345,6 @@ parameters:
 			path: CRM/Donrec/Lang/De/Xx.php
 
 		-
-			message: '#^Method CRM_Donrec_Lang_De_Xx\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang/De/Xx.php
-
-		-
 			message: '#^Method CRM_Donrec_Lang_De_Xx\:\:convert_number_to_words\(\) has parameter \$currency with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -1415,12 +1385,6 @@ parameters:
 			identifier: if.condNotBoolean
 			count: 1
 			path: CRM/Donrec/Lang/De/Xx.php
-
-		-
-			message: '#^Method CRM_Donrec_Lang_En_Us\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang/En/Us.php
 
 		-
 			message: '#^Offset int\<\-99, \-1\>\|int\<1, 19\> might not exist on array\{'''', ''one'', ''two'', ''three'', ''four'', ''five'', ''six'', ''seven'', \.\.\.\}\.$#'
@@ -1494,12 +1458,6 @@ parameters:
 			path: CRM/Donrec/Lang/Es/Es.php
 
 		-
-			message: '#^Method CRM_Donrec_Lang_Es_Es\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang/Es/Es.php
-
-		-
 			message: '#^Method CRM_Donrec_Lang_Es_Es\:\:convertGroup\(\) has parameter \$n with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -1540,12 +1498,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: CRM/Donrec/Lang/Es/Es.php
-
-		-
-			message: '#^Binary operation "\*" between non\-empty\-string and 100 results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: CRM/Donrec/Lang/Pl/Kwota.php
 
 		-
 			message: '#^BooleanAnd\: Condition between '',,'' and false are always false\.$#'
@@ -1591,7 +1543,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 2
+			count: 1
 			path: CRM/Donrec/Lang/Pl/Kwota.php
 
 		-
@@ -1621,18 +1573,6 @@ parameters:
 		-
 			message: '#^Method Kwota\:\:_licz\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang/Pl/Kwota.php
-
-		-
-			message: '#^Method Kwota\:\:_mnoznikSlownie\(\) has parameter \$i with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Donrec/Lang/Pl/Kwota.php
-
-		-
-			message: '#^Method Kwota\:\:_mnoznikSlownie\(\) has parameter \$licz with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: CRM/Donrec/Lang/Pl/Kwota.php
 
@@ -1676,12 +1616,6 @@ parameters:
 			message: '#^Only booleans are allowed in a negated boolean, int\|false given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 2
-			path: CRM/Donrec/Lang/Pl/Kwota.php
-
-		-
-			message: '#^Only booleans are allowed in a ternary operator condition, array\|null given\.$#'
-			identifier: ternary.condNotBoolean
-			count: 1
 			path: CRM/Donrec/Lang/Pl/Kwota.php
 
 		-
@@ -1767,12 +1701,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: CRM/Donrec/Lang/Pl/Kwota.php
-
-		-
-			message: '#^Method CRM_Donrec_Lang_Pl_Pl\:\:amount2words\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Lang/Pl/Pl.php
 
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
@@ -2438,12 +2366,6 @@ parameters:
 			path: CRM/Donrec/Logic/Profile.php
 
 		-
-			message: '#^Parameter \#1 \$array of function key expects array\|object, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Donrec/Logic/Profile.php
-
-		-
 			message: '#^Property CRM_Donrec_Logic_Profile\:\:\$data type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2624,12 +2546,6 @@ parameters:
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
-			message: '#^Offset ''currency'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
 			message: '#^Offset ''date_from'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
@@ -2660,33 +2576,15 @@ parameters:
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
-			message: '#^Offset ''financial_type_id'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
 			message: '#^Offset ''issued_by'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
-			message: '#^Offset ''issued_in'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 5
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
 			message: '#^Offset ''issued_on'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 5
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
-			message: '#^Offset ''non_deductible_amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
+			count: 4
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
@@ -2715,12 +2613,6 @@ parameters:
 
 		-
 			message: '#^Offset ''receipt_id'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
-			message: '#^Offset ''receive_date'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: CRM/Donrec/Logic/Receipt.php
@@ -2764,7 +2656,7 @@ parameters:
 		-
 			message: '#^Offset ''status'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 8
+			count: 7
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
@@ -2783,12 +2675,6 @@ parameters:
 			message: '#^Offset ''supplemental_address_2'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
-			path: CRM/Donrec/Logic/Receipt.php
-
-		-
-			message: '#^Offset ''total_amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
@@ -2828,27 +2714,9 @@ parameters:
 			path: CRM/Donrec/Logic/Receipt.php
 
 		-
-			message: '#^Cannot access offset ''id'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Cannot access offset ''is_error'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 2
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
 			path: CRM/Donrec/Logic/ReceiptItem.php
 
 		-
@@ -2876,87 +2744,9 @@ parameters:
 			path: CRM/Donrec/Logic/ReceiptItem.php
 
 		-
-			message: '#^Method CRM_Donrec_Logic_ReceiptItem\:\:getCustomFields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
 			message: '#^Method CRM_Donrec_Logic_ReceiptItem\:\:setStatusAll\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''contribution_hash'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''currency'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''financial_type_id'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''issued_by'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''issued_in'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 6
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''issued_on'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''non_deductible_amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''receipt_id'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''receive_date'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''status'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 6
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''total_amount'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
-			path: CRM/Donrec/Logic/ReceiptItem.php
-
-		-
-			message: '#^Offset ''type'' might not exist on array\|null\.$#'
-			identifier: offsetAccess.notFound
-			count: 3
 			path: CRM/Donrec/Logic/ReceiptItem.php
 
 		-
@@ -2985,6 +2775,18 @@ parameters:
 
 		-
 			message: '#^Cannot access offset ''financial_type_id'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: CRM/Donrec/Logic/ReceiptTokens.php
+
+		-
+			message: '#^Cannot access offset ''id'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: CRM/Donrec/Logic/ReceiptTokens.php
+
+		-
+			message: '#^Cannot access offset ''receive_date'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: CRM/Donrec/Logic/ReceiptTokens.php
@@ -3100,7 +2902,7 @@ parameters:
 		-
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
-			count: 1
+			count: 2
 			path: CRM/Donrec/Logic/ReceiptTokens.php
 
 		-
@@ -3941,18 +3743,6 @@ parameters:
 			path: CRM/Donrec/Page/Runner.php
 
 		-
-			message: '#^Cannot access offset 1 on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: CRM/Donrec/Page/Staging.php
-
-		-
-			message: '#^Cannot access offset 2 on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Donrec/Page/Staging.php
-
-		-
 			message: '#^Cannot call method getProfile\(\) on CRM_Donrec_Logic_Snapshot\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -4150,7 +3940,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 2
+			count: 1
 			path: CRM/Utils/DonrecHelper.php
 
 		-
@@ -4162,12 +3952,6 @@ parameters:
 		-
 			message: '#^Method CRM_Utils_DonrecHelper\:\:exitWithMessage\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:getFieldID\(\) has parameter \$fields with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: CRM/Utils/DonrecHelper.php
 
@@ -4184,68 +3968,8 @@ parameters:
 			path: CRM/Utils/DonrecHelper.php
 
 		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has parameter \$field_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has parameter \$fields with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has parameter \$form with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has parameter \$from_label with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:relabelDateField\(\) has parameter \$to_label with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:removeFromForm\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Method CRM_Utils_DonrecHelper\:\:removeFromForm\(\) has parameter \$fields with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, DateTime\|false given\.$#'
 			identifier: if.condNotBoolean
-			count: 1
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int given\.$#'
-			identifier: if.condNotBoolean
-			count: 2
-			path: CRM/Utils/DonrecHelper.php
-
-		-
-			message: '#^Parameter \#3 \$length of function substr expects int\|null, int\<0, max\>\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: CRM/Utils/DonrecHelper.php
 
@@ -4571,7 +4295,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 13
+			count: 12
 			path: donrec.php
 
 		-
@@ -4581,7 +4305,7 @@ parameters:
 			path: donrec.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, int given\.$#'
+			message: '#^Only booleans are allowed in an if condition, int\|null given\.$#'
 			identifier: if.condNotBoolean
 			count: 11
 			path: donrec.php

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -2,11 +2,6 @@ includes:
 	- phpstan.neon.dist
 
 parameters:
-	scanDirectories:
-		- vendor/civicrm/civicrm-core/api
-		- vendor/civicrm/civicrm-core/CRM
-		- vendor/civicrm/civicrm-packages/DB
-		- vendor/civicrm/civicrm-packages/HTML
 	bootstrapFiles:
 		- vendor/autoload.php
 	# Because we test with different versions in CI we may have unmatched errors.
@@ -16,9 +11,6 @@ parameters:
 
 		# Required with civicrm/civicrm-core <6.1.0
 		- '#^Call to an undefined static method Civi::rebuild\(\).$#'
-
-		# Required with civicrm/civicrm-core <6.12.0
-		- '#^Method CRM_Donrec_Logic_Profile::getFromEmailAddresses\(\) should return string but returns int\|string\|null.$#'
 
 		# Required with symfony/event-dispatcher <4.4.27
 		- '#::getSubscribedEvents\(\) return type has no value type specified in iterable type array.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,9 +27,13 @@ parameters:
 		- Civi\Core\Event\GenericHookEvent
 		- CRM_Core_Config
 		- CRM_Core_DAO
+		- civicrm_api3
 	earlyTerminatingMethodCalls:
+		CRM_Core_Error:
+			- statusBounce
 		CRM_Utils_System:
 			- civiExit
+			- redirect
 		CRM_Queue_Runner:
 			- runAllViaWeb
 	checkTooWideReturnTypesInProtectedAndPublicMethods: true

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -1,26 +1,10 @@
 # Copy this file to phpstan.neon and replace {VENDOR_DIR} with the appropriate
-# path.
+# path. In installations without composer (e.g. as WordPress plugin) the vendor
+# directoy is inside the CiviCRM folder.
 
 includes:
 	- phpstan.neon.dist
 
 parameters:
-	scanDirectories:
-		- {VENDOR_DIR}/civicrm/civicrm-core/api
-		- {VENDOR_DIR}/civicrm/civicrm-core/CRM
-		- {VENDOR_DIR}/civicrm/civicrm-packages/DB
-		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php
-
-# For installations without composer (e.g. as WordPress plugin),
-# replace the parameters section above with the following configuration:
-#
-#parameters:
-#	scanDirectories:
-#		- {CIVICRM_DIR}/api
-#		- {CIVICRM_DIR}/CRM
-#		- {CIVICRM_DIR}/packages/DB
-#		- {CIVICRM_DIR}/packages/HTML
-#	bootstrapFiles:
-#		- {CIVICRM_DIR}/vendor/autoload.php

--- a/phpstanBootstrap.php
+++ b/phpstanBootstrap.php
@@ -20,6 +20,9 @@ declare(strict_types = 1);
 // phpcs:disable Drupal.Commenting.DocComment.ContentAfterOpen
 /** @var \PHPStan\DependencyInjection\Container $container */
 /** @phpstan-var array<string> $bootstrapFiles */
+
+use Composer\Autoload\ClassLoader;
+
 $bootstrapFiles = $container->getParameter('bootstrapFiles');
 foreach ($bootstrapFiles as $bootstrapFile) {
   if (str_ends_with($bootstrapFile, 'vendor/autoload.php')) {
@@ -37,15 +40,27 @@ foreach ($bootstrapFiles as $bootstrapFile) {
       continue;
     }
     if (file_exists($civiCrmCoreDir)) {
-      set_include_path(get_include_path()
+      set_include_path(
+        get_include_path()
         . PATH_SEPARATOR . $civiCrmCoreDir
         . PATH_SEPARATOR . $civiCrmPackagesDir
       );
-      // $bootstrapFile might not be included, yet. It is required for the
-      // following require_once, though.
-      require_once $bootstrapFile;
-      // Prevent error "Class 'CRM_Core_Exception' not found in file".
-      require_once $civiCrmCoreDir . '/CRM/Core/Exception.php';
+
+      require_once 'api/api.php';
+      require_once 'api/v3/utils.php';
+      require_once 'api/v3/Generic.php';
+      /** @var list<string> $api3GenericFiles */
+      $api3GenericFiles = glob("$civiCrmCoreDir/api/v3/Generic/*.php");
+      array_map(fn ($file) => require_once $file, $api3GenericFiles);
+
+      $loader = new ClassLoader();
+      $loader->addClassMap([
+        'civicrm_api3' => "$civiCrmCoreDir/api/class.api.php",
+        'API_Wrapper' => "$civiCrmCoreDir/api/Wrapper.php",
+      ]);
+      $loader->add('CRM_', [$civiCrmCoreDir]);
+      $loader->add('DB_', [$civiCrmPackagesDir]);
+      $loader->add('HTML_', [$civiCrmPackagesDir]);
 
       // The class \Smarty extended by \CRM_Core_SmartyCompatibility uses the
       // __call() method to delegate method calls to \Smarty\Smarty, but hasn't
@@ -56,6 +71,20 @@ foreach ($bootstrapFiles as $bootstrapFile) {
         require_once $smartyAutoloadFile;
         class_alias(\Smarty\Smarty::class, 'Smarty');
       }
+
+      $coreExtDirs = glob("$civiCrmCoreDir/ext/*");
+      if (FALSE !== $coreExtDirs) {
+        foreach ($coreExtDirs as $extensionDir) {
+          if (is_dir("$extensionDir/CRM")) {
+            $loader->add('CRM_', [$extensionDir]);
+          }
+          if (is_dir("$extensionDir/Civi")) {
+            $loader->addPsr4('Civi\\', [$extensionDir . '/Civi']);
+          }
+        }
+      }
+
+      $loader->register();
 
       break;
     }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,6 +25,8 @@ require_once __DIR__ . '/../../donrec.civix.php';
 
 // Add test classes to class loader.
 addExtensionDirToClassLoader(__DIR__);
+
+// Add classes for tests without booted CiviCRM environment, i.e. simple PHPUnit tests.
 addExtensionToClassLoader('de.systopia.donrec');
 
 if (!function_exists('ts')) {
@@ -40,7 +42,26 @@ function _donrec_test_civicrm_container(ContainerBuilder $container): void {
 }
 
 function addExtensionToClassLoader(string $extension): void {
-  addExtensionDirToClassLoader(__DIR__ . '/../../../' . $extension);
+  // Support symlinks. Current working dir should be the extensions' directory
+  // relative to the "ext" directory.
+  // Note: getcwd() is not used because it returns the real path.
+  /** @var string $currentWorkingDir */
+  $currentWorkingDir = getenv('PWD');
+  $candidates = [
+    dirname($currentWorkingDir) . '/' . $extension,
+    __DIR__ . '/../../../' . $extension,
+  ];
+
+  foreach ($candidates as $candidate) {
+    $real = realpath($candidate);
+    if ($real !== FALSE && is_dir($real)) {
+      addExtensionDirToClassLoader($real);
+
+      return;
+    }
+  }
+
+  throw new RuntimeException("Extension path not found for: $extension");
 }
 
 function addExtensionDirToClassLoader(string $extensionDir): void {
@@ -63,6 +84,7 @@ function addExtensionDirToClassLoader(string $extensionDir): void {
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return mixed
  *   Response output (if the command executed normally).
  *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
@@ -96,6 +118,7 @@ function cv(string $cmd, string $decode = 'json') {
       if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
         throw new \RuntimeException("Command failed ($cmd):\n$result");
       }
+
       return $result;
 
     case 'json':

--- a/tools/git/hooks/pre-commit.d/remember-update-pot.sh
+++ b/tools/git/hooks/pre-commit.d/remember-update-pot.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 echo "Please remember to update the .pot file (tools/update-pot.sh) and the translation."
-

--- a/tools/update-pot.sh
+++ b/tools/update-pot.sh
@@ -20,7 +20,7 @@ EOD
 
 if [ $# -eq 1 ]; then
   usage
-  if [ $1 = -h ] || [ $1 = --help ]; then
+  if [ "$1" = -h ] || [ "$1" = --help ]; then
     exit
   fi
   exit 1


### PR DESCRIPTION
The switch to manged entities for custom groups https://github.com/systopia/de.systopia.donrec/pull/235 results in fixed column names without ID (on new installations). This leads to this error:
```
[...]/de.systopia.donrec/CRM/Utils/DonrecHelper.php:128 {
        CRM_Utils_DonrecHelper::getFieldID($fields, $field_name)
        › $inv_column = strrev($fields[$field_name]);
        › $inv_id = substr($inv_column, 0, strpos($inv_column, '_'));
        › return (int) strrev($inv_id);
        arguments: {
          $string: "ycnerruc"
          $offset: 0
          $length: false
        }
      }
      [...]/de.systopia.donrec/donrec.php:445 { …}
```

This is fixed by this PR. The method `CRM_Utils_DonrecHelper::getFieldID()` is renamed to `CRM_Utils_DonrecHelper::getColumnFieldId()` only expects the field name as argument.

The methods `removeFromForm()` and `relabelDateField()` where calling `CRM_Utils_DonrecHelper::getFieldID()`, but weren't used, anywhere. They are removed now.

The method `\CRM_Donrec_Logic_ReceiptItem::getCustomFields()` is now much simpler by using APIv4.

Additionally the extension template is updated and new phpstan errors reported by the current version are resolved or added to the baseline.

systopia-reference: 34820