### PR TITLE
Only use explicit Smarty methods

### DIFF
--- a/CRM/Donrec/Logic/Template.php
+++ b/CRM/Donrec/Logic/Template.php
@@ -170,19 +170,17 @@ class CRM_Donrec_Logic_Template {
    *   The filename or FALSE if an error occurred.
    */
   public function generatePDF($values, &$parameters, $profile) {
-    $smarty = CRM_Core_Smarty::singleton();
     $config = CRM_Core_Config::singleton();
 
-    // assign all values
-    foreach ($values as $token => $value) {
-      $smarty->assign($token, $value);
-    }
+    $smartyVars = $this->profile_variables + $values;
+    $smartyVars['profile_variables'] = $this->profile_variables;
 
-    // Assign profile variables.
-    $smarty->assign('profile_variables', $this->profile_variables);
-    foreach ($this->profile_variables as $name => $value) {
-      $smarty->assign($name, $value);
-    }
+    // identify pdf engine
+    $smartyVars['wk_enabled'] = !empty($config->wkhtmltopdfPath);
+
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->pushScope([]);
+    $smarty->assignAll($smartyVars);
 
     // callback for custom variables
     CRM_Utils_DonrecCustomisationHooks::pdf_unique_token($smarty, $values);
@@ -208,16 +206,11 @@ class CRM_Donrec_Logic_Template {
     $watermark = new $watermark_class();
     $watermark->injectMarkup($html, $pdf_format);
     $watermark->injectStyles($html, $pdf_format);
-
-    // identify pdf engine
-    $smarty->assign('wk_enabled', !empty($config->wkhtmltopdfPath));
-
     // --- watermark injection end ---
-    // compile template
-    $html = $smarty->fetch("string:$html");
 
-    // reset template variables
-    $smarty->clearTemplateVars();
+    // compile template
+    $html = $smarty->fetchWith("string:$html", []);
+    $smarty->popScope();
 
     // set up file names
     $filename_export = CRM_Donrec_Logic_File::makeFileName(
@@ -227,7 +220,7 @@ class CRM_Donrec_Logic_Template {
 
     // render PDF receipt
     $result = file_put_contents($filename_export, CRM_Utils_PDF_Utils::html2pdf(
-      $html,
+      [$html],
       '',
       TRUE,
       $this->pdf_format_id

--- a/CRM/Utils/DonrecCustomisationHooks.php
+++ b/CRM/Utils/DonrecCustomisationHooks.php
@@ -22,24 +22,23 @@ class CRM_Utils_DonrecCustomisationHooks {
    * You should use this when the token cannot be shared between chunk items (for example a
    * unique document id that is part of the pdf file)
    *
-   * You can implement this hook to add/modify template tokens
-   * e.g. in your hook implementation call $template->assign('myCustomToken', 'my custom token');
-   * and place a token called {$myCustomToken} in the template.
+   * You can implement this hook to add/modify template tokens e.g. in your hook
+   * implementation call
+   * $template->assignAll(['myCustomToken' => 'my custom token']);
+   * to place a token called {$myCustomToken} in the template.
    *
-   * @param object $template
-   * @param-out object $template
-   *
-   * @param mixed $chunk_item
+   * @param array<string, mixed> $chunk_item
    *
    * @return mixed based on op. pre-hooks return a boolean or
    *   an error message which aborts the operation
    * @access public
    */
-  public static function pdf_unique_token(&$template, &$chunk_item) {
+  public static function pdf_unique_token(\CRM_Core_Smarty &$template, array &$chunk_item) {
     return CRM_Utils_Hook::singleton()->invoke(
       ['template', 'chunk_item'],
-      // @phpstan-ignore paramOut.type
+      // @phpstan-ignore parameterByRef.type
       $template,
+      // @phpstan-ignore parameterByRef.type
       $chunk_item,
       self::$null,
       self::$null,

--- a/CRM/Utils/DonrecHelper.php
+++ b/CRM/Utils/DonrecHelper.php
@@ -66,12 +66,11 @@ class CRM_Utils_DonrecHelper {
     $smarty = CRM_Core_Smarty::singleton();
     $template = file_get_contents(dirname(__DIR__) . '../../templates/fatal_error.tpl');
 
-    // assign values
-    $smarty->assign('title', E::ts('Error'));
-    $smarty->assign('headline', E::ts('Error'));
-    $smarty->assign('description', $error_message);
-
-    $html = $smarty->fetch("string:$template");
+    $html = $smarty->fetchWith("string:$template", [
+      'title' => E::ts('Error'),
+      'headline' => E::ts('Error'),
+      'description' => $error_message,
+    ]);
     exit($html);
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3457,26 +3457,8 @@ parameters:
 			path: CRM/Donrec/Logic/Template.php
 
 		-
-			message: '#^Call to an undefined method object\:\:assign\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: CRM/Donrec/Logic/Template.php
-
-		-
-			message: '#^Call to an undefined method object\:\:clearTemplateVars\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: CRM/Donrec/Logic/Template.php
-
-		-
 			message: '#^Call to an undefined method object\:\:fetch\(\)\.$#'
 			identifier: method.notFound
-			count: 2
-			path: CRM/Donrec/Logic/Template.php
-
-		-
-			message: '#^Cannot access offset ''contributor'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: CRM/Donrec/Logic/Template.php
 


### PR DESCRIPTION
Previously there were Smarty methods called that were only implicitly available via `__call()`.